### PR TITLE
fix: build oidc callback url in a more proper way

### DIFF
--- a/app/utils/oidc.ts
+++ b/app/utils/oidc.ts
@@ -51,8 +51,8 @@ export async function startOidc(oidc: OidcConfig, req: Request) {
 	const challenge = await calculatePKCECodeChallenge(verifier)
 
 	const callback = new URL('/admin/oidc/callback', req.url)
-	callback.protocol = req.url.includes('localhost') ? 'http:' : 'https:'
-	callback.hostname = req.headers.get('Host') ?? ''
+	callback.protocol = req.headers.get('X-Forwarded-Proto') ?? 'http:'
+	callback.host = req.headers.get('Host') ?? ''
 	const authUrl = new URL(processed.authorization_endpoint)
 
 	authUrl.searchParams.set('client_id', oidcClient.client_id)
@@ -119,8 +119,8 @@ export async function finishOidc(oidc: OidcConfig, req: Request) {
 	}
 
 	const callback = new URL('/admin/oidc/callback', req.url)
-	callback.protocol = req.url.includes('localhost') ? 'http:' : 'https:'
-	callback.hostname = req.headers.get('Host') ?? ''
+	callback.protocol = req.headers.get('X-Forwarded-Proto') ?? 'http:'
+	callback.host = req.headers.get('Host') ?? ''
 
 	const tokenResponse = await authorizationCodeGrantRequest(
 		processed,


### PR DESCRIPTION
Removes the need to check for 'localhost' in the URL, thus reducing potential errors (e.g., a domain like "not-localhost.com" mistakenly triggering `http`). By using the standard `X-Forwarded-Proto` header, the handling of requests becomes more reliable in both local development and production environments.

The `host` property is used instead of `hostname` to build the OIDC callback URL because `host` includes the port (when nonempty), whereas `hostname` does not, according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/URL/host).