### PR TITLE
chore: update outdated docs links

### DIFF
--- a/app/routes/acls/editor.tsx
+++ b/app/routes/acls/editor.tsx
@@ -227,7 +227,7 @@ export default function Page() {
 				and the
 				{' '}
 				<Link
-					to="https://headscale.net/acls"
+					to="https://headscale.net/stable/ref/acls/"
 					name="Headscale ACL documentation"
 				>
 					Headscale docs

--- a/app/routes/dns/components/dns.tsx
+++ b/app/routes/dns/components/dns.tsx
@@ -28,7 +28,7 @@ export default function DNS({ records, isDisabled }: Props) {
 				records are supported.
 				{' '}
 				<Link
-					to="https://headscale.net/dns-records/"
+					to="https://headscale.net/stable/ref/dns"
 					name="Headscale DNS Records documentation"
 				>
 					Learn More

--- a/app/routes/users/components/auth.tsx
+++ b/app/routes/users/components/auth.tsx
@@ -24,7 +24,7 @@ export default function Auth({ magic }: Props) {
 						experience when using Headscale.
 						{' '}
 						<Link
-							to="https://headscale.net/oidc"
+							to="https://headscale.net/stable/ref/oidc"
 							name="Headscale OIDC Documentation"
 						>
 							Learn more

--- a/app/routes/users/components/oidc.tsx
+++ b/app/routes/users/components/oidc.tsx
@@ -30,7 +30,7 @@ export default function Oidc({ oidc, magic }: Props) {
 						Groups and user information do not automatically sync.
 						{' '}
 						<Link
-							to="https://headscale.net/oidc"
+							to="https://headscale.net/stable/ref/oidc"
 							name="Headscale OIDC Documentation"
 						>
 							Learn more


### PR DESCRIPTION
Some links were out of date and were throwing up a 404s.