### PR TITLE
fix: Reusable Pre-Auth Keys no longer show expired when used

### DIFF
--- a/app/routes/settings/auth-keys.tsx
+++ b/app/routes/settings/auth-keys.tsx
@@ -137,7 +137,7 @@ export default function Page() {
 			const expiry = new Date(key.expiration);
 
 			if (status === 'Active') {
-				return !(expiry < now) && !key.used;
+				return !(expiry < now) && (!key.used || key.reusable);
 			}
 
 			if (status === 'Used/Expired') {

--- a/app/routes/settings/components/key.tsx
+++ b/app/routes/settings/components/key.tsx
@@ -31,7 +31,7 @@ export default function AuthKeyRow({ authKey, server }: Props) {
 				tailscale up --login-server {server} --authkey {authKey.key}
 			</Code>
 			<div className="flex gap-4 items-center">
-				{authKey.used ||
+				{authKey.used && !authKey.reusable ||
 				new Date(authKey.expiration) < new Date() ? undefined : (
 					<ExpireKey authKey={authKey} />
 				)}


### PR DESCRIPTION
Very simple change. Reusable keys are marked as expired when used. Even if the key was told to expire early by a command headscale just changes the expiry date, meaning that reusable keys are only expired/no longer usable based on the expiry date.
Note: this also means reusable keys will show up in used/expired when used. This could be split up if needed.