### PR TITLE
Add breaking change warning to CHANGELOG + fix Docker socket path in config example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fixed the Kubernetes integration not reading the config
 
 ### 0.5 (February 27, 2025)
+
+> [!IMPORTANT]  
+> This release introduces breaking changes. Headplane version 0.5.0 and above expect Headscale's oidc.scope to be a string instead of an array. (Change `scope: ["openid", "profile", "email"]` to `scope: "openid profile email"`) If not changed, https://github.com/tale/headplane/issues/111 will occur and Headplane will be limited to Simple Mode.
+
 - Completely redesigned the UI from the ground up for accessibility and performance.
 - Switched to a config-file setup (this introduces breaking changes, see [config.example.yaml](/config.example.yaml) for the new format).
 - If the config is read-only, the options are still visible, just disabled (fixes [#48](https://github.com/tale/headplane/issues/48))

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,7 +44,7 @@ integration:
         # The path to the Docker socket (do not change this if you are unsure)
         # Docker socket paths must start with unix:// or tcp:// and at the moment
         # https connections are not supported.
-        socket: "unix:///var/run/docker.dock"
+        socket: "unix:///var/run/docker.sock"
     # Please refer to docs/integration/Kubernetes.md for more information
     # on how to configure the Kubernetes integration. There are requirements in
     # order to allow Headscale to be controlled by Headplane in a cluster.


### PR DESCRIPTION
This fixes a typo in `config.example.yaml` from `docker.dock` to `docker.sock`, which fixes the error of:
```
2025-02-28T23:42:10.733323552Z 2025-02-28T23:42:10.733Z (INFO) [INTG] Checking socket: /var/run/docker.dock
2025-02-28T23:42:10.865147278Z 2025-02-28T23:42:10.864Z (ERRO) [INTG] Failed to access Docker socket: /var/run/docker.dock
2025-02-28T23:42:10.867129530Z 2025-02-28T23:42:10.865Z (ERRO) [INTG] Integration DockerIntegration {
2025-02-28T23:42:10.867138928Z   context: [Object],
2025-02-28T23:42:10.867141423Z   maxAttempts: 10,
2025-02-28T23:42:10.867143426Z   client: undefined
2025-02-28T23:42:10.867145170Z } is not available
```