### PR TITLE
Fix mkey related bug

### DIFF
--- a/app/routes/machines/dialogs/new.tsx
+++ b/app/routes/machines/dialogs/new.tsx
@@ -21,7 +21,7 @@ export default function New(data: NewProps) {
 	return (
 		<>
 			<Dialog isOpen={pushDialog} onOpenChange={setPushDialog}>
-				<Dialog.Panel isDisabled={!mkey.trim().startsWith('mkey:')}>
+				<Dialog.Panel isDisabled={mkey.length < 1}>
 					<Dialog.Title>Register Machine Key</Dialog.Title>
 					<Dialog.Text className="mb-4">
 						The machine key is given when you run{' '}
@@ -36,7 +36,7 @@ export default function New(data: NewProps) {
 					<Input
 						isRequired
 						label="Machine Key"
-						placeholder="mkey:ff....."
+						placeholder="AbCd..."
 						validationBehavior="native"
 						name="mkey"
 						onChange={setMkey}


### PR DESCRIPTION
String "mkey:" was being appended to the node registration http request causing it to fail. Removed mkey presence check and changed default hint. Form validation is based on length instead.

Addresses #116 and #130 