### PR TITLE
[Minor] Systemd service: restart with headscale, update server.js path

### DIFF
--- a/docs/Bare-Metal.md
+++ b/docs/Bare-Metal.md
@@ -68,14 +68,15 @@ Headplane service:
 ```ini
 [Unit]
 Description=Headplane
-After=network.target
+# Decomment the following line if running on bare metal with integrated mode (/proc integration)
+# PartOf=headscale.service
 
 [Service]
 Type=simple
 User=headplane
 Group=headplane
 WorkingDirectory=/path/to/headplane
-ExecStart=/usr/bin/node /path/to/headplane/build/headplane/server.js
+ExecStart=/usr/bin/node /path/to/headplane/build/server/index.js
 Restart=always
 
 [Install]


### PR DESCRIPTION
Hello, very minor change here. I've just added a `PartOf` entry in the unit that will automatically restart the headplane systemd service whenever headscale is restarted, to take care of the warning in the last paragraph here https://github.com/tale/headplane/blob/main/docs/Integrated-Mode.md#native-linux-proc-integration

Also, while I was there I've changed the server.js path