### PR TITLE
feat: add filtering by container label for Docker integration

### DIFF
--- a/app/server/config/schema.ts
+++ b/app/server/config/schema.ts
@@ -41,10 +41,16 @@ const headscaleConfig = type({
 	config_strict: stringToBool,
 }).onDeepUndeclaredKey('reject');
 
+const containerLabel = type({
+	name: 'string',
+	value: 'string',
+}).optional();
+
 const dockerConfig = type({
 	enabled: stringToBool,
 	container_name: 'string',
 	socket: 'string = "unix:///var/run/docker.sock"',
+	container_label: containerLabel,
 });
 
 const kubernetesConfig = type({

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,8 @@ services:
   headscale:
     image: "headscale/headscale:0.25.1"
     container_name: "headscale"
+    labels:
+      - com.headplane.selector=headscale
     restart: "unless-stopped"
     command: "serve"
     networks:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,6 +49,12 @@ integration:
     enabled: false
     # The name (or ID) of the container running Headscale
     container_name: "headscale"
+    # The label that will be used to identify the container running Headscale.
+    # This can be omitted if the container name is known in advance and is not
+    # subject to changes.
+    container_label:
+      name: "workload.headscale.io/name"
+      value: "headscale"
     # The path to the Docker socket (do not change this if you are unsure)
     # Docker socket paths must start with unix:// or tcp:// and at the moment
     # https connections are not supported.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,14 +47,14 @@ headscale:
 integration:
   docker:
     enabled: false
-    # The name (or ID) of the container running Headscale
-    container_name: "headscale"
-    # The label that will be used to identify the container running Headscale.
-    # This can be omitted if the container name is known in advance and is not
-    # subject to changes.
+    # Preferred method: use container_label to dynamically discover the Headscale container.
     container_label:
-      name: "workload.headscale.io/name"
+      name: "com.headplane.selector"
       value: "headscale"
+    # Optional fallback: directly specify the container name (or ID)
+    # of the container running Headscale
+    # container_name: "headscale"
+
     # The path to the Docker socket (do not change this if you are unsure)
     # Docker socket paths must start with unix:// or tcp:// and at the moment
     # https connections are not supported.

--- a/docs/Integrated-Mode.md
+++ b/docs/Integrated-Mode.md
@@ -74,7 +74,10 @@ The Docker integration is the easiest to setup, as it only requires the Docker s
 to be mounted into the container along with some configuration. As long as Headplane
 has access to the Docker socket and the name of the Headscale container, it will
 automatically propagate config and DNS changes to Headscale without any additional
-configuration.
+configuration. Additionally, instead of specifying the name of the Headscale
+container, it is possible to use a label to dynamically deduce the container
+name. This can be useful if the container name changes frequently, or is not
+known in advance.
 
 ## Native Linux (/proc) Integration
 The `proc` integration is used when you are running Headscale and Headplane on

--- a/docs/Integrated-Mode.md
+++ b/docs/Integrated-Mode.md
@@ -70,14 +70,14 @@ you build the container yourself or run Headplane in Bare-Metal mode.
 > setting up your `config.yaml` file to the appropriate values.
 
 ## Docker Integration
-The Docker integration is the easiest to setup, as it only requires the Docker socket
-to be mounted into the container along with some configuration. As long as Headplane
-has access to the Docker socket and the name of the Headscale container, it will
-automatically propagate config and DNS changes to Headscale without any additional
-configuration. Additionally, instead of specifying the name of the Headscale
-container, it is possible to use a label to dynamically deduce the container
-name. This can be useful if the container name changes frequently, or is not
-known in advance.
+The Docker integration is the easiest to set up, as it only requires mounting the
+Docker socket into the container along with some basic configuration. Headplane
+uses Docker labels to discover the Headscale container. As long as Headplane has
+access to the Docker socket and can identify the Headscale container—either by
+label or name—it will automatically propagate configuration and DNS changes to
+Headscale without any additional setup. Alternatively, instead of using a label
+to dynamically determine the container name, it is possible to directly specify
+the container name.
 
 ## Native Linux (/proc) Integration
 The `proc` integration is used when you are running Headscale and Headplane on


### PR DESCRIPTION
This commit introduces the ability to filter Docker containers by their labels, instead of container names, in the Docker integration. This functionality allows dynamic container name resolution, which is particularly useful in environments where container names may change frequently or are not predefined.

- Added container_label field to the dockerConfig type
- Updated DockerIntegration.isAvailable()  to deduce the container name from `container_label` if the container name is not provided
- Updated configuration example and documentation to include the new feature

This is my first time writing TypeScript, so I'd appreciate any feedback or suggestions on improving the code, especially regarding style or best practices.

Fixes #193