### PR TITLE
fix: fallback to user email when username is unset

### DIFF
--- a/app/routes/machines/components/machine-row.tsx
+++ b/app/routes/machines/components/machine-row.tsx
@@ -63,7 +63,9 @@ export default function MachineRow({
 					>
 						{node.givenName}
 					</p>
-					<p className="text-sm opacity-50">{node.user.name}</p>
+					<p className="text-sm opacity-50">
+						{node.user.name ?? node.user.email}
+					</p>
 					<div className="flex gap-1 flex-wrap mt-1.5">
 						{mapTagsToComponents(node, uiTags)}
 						{node.validTags.map((tag) => (

--- a/app/routes/machines/machine.tsx
+++ b/app/routes/machines/machine.tsx
@@ -109,7 +109,7 @@ export default function Page() {
 					</span>
 					<div className="flex items-center gap-x-2.5 mt-1">
 						<UserCircle />
-						{node.user.name}
+						{node.user.name ?? node.user.email}
 					</div>
 				</div>
 				<div className="p-2 pl-4">
@@ -254,7 +254,7 @@ export default function Page() {
 				className="w-full max-w-full grid grid-cols-1 lg:grid-cols-2 gap-y-2 sm:gap-x-12"
 			>
 				<div className="flex flex-col gap-1">
-					<Attribute name="Creator" value={node.user.name} />
+					<Attribute name="Creator" value={node.user.name ?? node.user.email} />
 					<Attribute name="Machine name" value={node.givenName} />
 					<Attribute
 						tooltip="OS hostname is published by the machine’s operating system and is used as the default name for the machine."


### PR DESCRIPTION
More recent versions of Headscale have changed username to be an optional field, causing the Machines page to show an empty field where the username would normally be displayed. This PR makes it fallback to displaying the email when this is the case.

I'm not very familiar with React, so let me know if there's a better way to do this. I'd love to be able to see which user manages a machine at a glance again!

## Before
<img width="500" src="https://github.com/user-attachments/assets/d8b23d75-5877-429d-9790-c16479393acc" />
<img width="200" src="https://github.com/user-attachments/assets/68dc1edb-f994-404a-9b5b-b33d14447beb" />
<img width="500" src="https://github.com/user-attachments/assets/fca15d70-75f6-4b03-99c2-038a0e652320" />

## After
<img width="500" src="https://github.com/user-attachments/assets/b896859a-e118-4945-96d2-40975d14f9eb" />
<img width="200" src="https://github.com/user-attachments/assets/43b9f4c0-55dc-486d-8a28-04eea6c85dc7" />
<img width="500" src="https://github.com/user-attachments/assets/4cd1dffc-6321-4893-9db2-31a5dda2b9dd" />