### PR TITLE
fix: update nix deps hash

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-OOWgYaGwa5PtWhFEEkRCojCDmkPIR6tJ5cfFMOLND3I=";
+    hash = "sha256-xjjkqbgjYaAGYAmlTFE+Lq3Hp6myZKaW3br0YTDNhQA=";
   };
 
   buildPhase = ''


### PR DESCRIPTION
Currently it fails to build with
```
error: hash mismatch in fixed-output derivation '/nix/store/z1515z0xzl31480j6sj2ys38rfbhm83a-headplane-pnpm-deps.drv':
         specified: sha256-OOWgYaGwa5PtWhFEEkRCojCDmkPIR6tJ5cfFMOLND3I=
            got:    sha256-xjjkqbgjYaAGYAmlTFE+Lq3Hp6myZKaW3br0YTDNhQA=
```
