### PR TITLE
fix: username never falling back to email

### DIFF
--- a/app/routes/machines/components/machine-row.tsx
+++ b/app/routes/machines/components/machine-row.tsx
@@ -64,7 +64,7 @@ export default function MachineRow({
 						{node.givenName}
 					</p>
 					<p className="text-sm opacity-50">
-						{node.user.name ?? node.user.email}
+						{node.user.name || node.user.email}
 					</p>
 					<div className="flex gap-1 flex-wrap mt-1.5">
 						{mapTagsToComponents(node, uiTags)}

--- a/app/routes/machines/machine.tsx
+++ b/app/routes/machines/machine.tsx
@@ -109,7 +109,7 @@ export default function Page() {
 					</span>
 					<div className="flex items-center gap-x-2.5 mt-1">
 						<UserCircle />
-						{node.user.name ?? node.user.email}
+						{node.user.name || node.user.email}
 					</div>
 				</div>
 				<div className="p-2 pl-4">
@@ -254,7 +254,7 @@ export default function Page() {
 				className="w-full max-w-full grid grid-cols-1 lg:grid-cols-2 gap-y-2 sm:gap-x-12"
 			>
 				<div className="flex flex-col gap-1">
-					<Attribute name="Creator" value={node.user.name ?? node.user.email} />
+					<Attribute name="Creator" value={node.user.name || node.user.email} />
 					<Attribute name="Machine name" value={node.givenName} />
 					<Attribute
 						tooltip="OS hostname is published by the machine’s operating system and is used as the default name for the machine."


### PR DESCRIPTION
Hey! #237 doesn't work correctly since username isn't actually null or undefined. When unset, it is an empty string, which doesn't trigger a fallback with a nullish coalescing operator. This PR changes the fallback to be a logical or, which will fallback when username is set to `""`.