### PR TITLE
fix: set pnpm.fetchDeps `fetcherVersion` to 1

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
+    fetcherVersion = 1;
     hash = "sha256-xjjkqbgjYaAGYAmlTFE+Lq3Hp6myZKaW3br0YTDNhQA=";
   };
 


### PR DESCRIPTION
This PR fixes the Nix build. Since https://github.com/NixOS/nixpkgs/pull/422975 setting a `fetcherVersion` got required. Setting it to `1` just keeps fetch behavior as it behaved before.
Also see: https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion
