### PR TITLE
fix: explicitly specify pnpm fetcherVersion

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
+    fetcherVersion = 2;
     hash = "sha256-xjjkqbgjYaAGYAmlTFE+Lq3Hp6myZKaW3br0YTDNhQA=";
   };
 


### PR DESCRIPTION
Hi, thank you for headplane.

I've been getting this error when trying to build my NixOS config when using nixpkgs from master branch.

<details>
<summary>Logs</summary>

```nix
… while evaluating derivation 'headplane-0.6.0'
  whose name attribute is located at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/pkgs/stdenv/generic/make-derivation.nix:480:13

… while evaluating attribute 'pnpmDeps' of derivation 'headplane-0.6.0'
  at /nix/store/j5mdwikhpxxa0s004j5cbvw9aq2pgx4n-source/nix/package.nix:24:3:
    23|
    24|   pnpmDeps = pnpm_10.fetchDeps {
      |   ^
    25|     inherit (finalAttrs) pname version src;

… while calling a functor (an attribute set with a '__functor' attribute)
  at /nix/store/j5mdwikhpxxa0s004j5cbvw9aq2pgx4n-source/nix/package.nix:24:14:
    23|
    24|   pnpmDeps = pnpm_10.fetchDeps {
      |              ^
    25|     inherit (finalAttrs) pname version src;

… from call site
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/lib/trivial.nix:989:5:
   988|     # TODO: Should we add call-time "type" checking like built in?
   989|     __functor = self: f;
      |     ^
   990|     __functionArgs = args;

… while calling anonymous lambda
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/lib/customisation.nix:161:7:
   160|     mirrorArgs (
   161|       origArgs:
      |       ^
   162|       let

… while evaluating a branch condition
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/lib/customisation.nix:173:7:
   172|       in
   173|       if isAttrs result then
      |       ^
   174|         result

… while calling the 'isAttrs' builtin
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/lib/customisation.nix:173:10:
   172|       in
   173|       if isAttrs result then
      |          ^
   174|         result

… from call site
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/lib/customisation.nix:163:18:
   162|       let
   163|         result = f origArgs;
      |                  ^
   164|

… while calling anonymous lambda
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/pkgs/development/tools/pnpm/fetch-deps/default.nix:23:5:
    22|   fetchDeps = lib.makeOverridable (
    23|     {
      |     ^
    24|       hash ? "",

… in the condition of the assert statement
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/pkgs/development/tools/pnpm/fetch-deps/default.nix:54:5:
    53|
    54|     assert (lib.throwIf (fetcherVersion == null)
      |     ^
    55|       "pnpm.fetchDeps: `fetcherVersion` is not set, see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."

… from call site
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/pkgs/development/tools/pnpm/fetch-deps/default.nix:54:13:
    53|
    54|     assert (lib.throwIf (fetcherVersion == null)
      |             ^
    55|       "pnpm.fetchDeps: `fetcherVersion` is not set, see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."

… while calling 'throwIf'
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/lib/trivial.nix:914:19:
   913|   */
   914|   throwIf = cond: msg: if cond then throw msg else x: x;
      |                   ^
   915|

… while calling the 'throw' builtin
  at /nix/store/na6rhshxw5v9vw0vnc35zpbzmrnklbca-source/lib/trivial.nix:914:37:
   913|   */
   914|   throwIf = cond: msg: if cond then throw msg else x: x;
      |                                     ^
   915|

error: pnpm.fetchDeps: `fetcherVersion` is not set, see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion.
```

</details>

Full error logs can be found here: https://github.com/ritiek/dotfiles/actions/runs/17064276259/job/48377668106

Seems it's mandatory to pass `fetcherVersion` to pnpm fetchDeps in recent changes on nixpkgs side. This change fixes it.