### PR TITLE
Add CI build doco

### DIFF
--- a/docs/CI-Build.md
+++ b/docs/CI-Build.md
@@ -2,7 +2,7 @@
 
 ## Gitlab
 
-To build heaplane using a Gitlab docker runner.
+To build heaplane using a Gitlab docker runner and add it to the generic package registry.
 
 ###### .gitlab-ci.yml
 


### PR DESCRIPTION
Kia ora,

I'm using a Gitlab CI to build headplane, so it's ready to be deployed on a bare-metal installation.
I think it can be a good add for the documentation.

Cheers,
