### PR TITLE
Fix auto populating an empty oidc block

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -26,7 +26,13 @@
     ]
     settingsWithAgentExecutablePath;
   settingsWithoutNulls = filterAttrsRecursive (key: value: value != null) settingsWithoutAgentPackage;
-  settingsFile = settingsFormat.generate "headplane-config.yaml" settingsWithoutNulls;
+  settingsWithoutEmptyOidc = 
+    if settingsWithoutNulls ? oidc && 
+       ((settingsWithoutNulls.oidc.issuer or "") == "" && (settingsWithoutNulls.oidc.client_id or "") == "") then
+      builtins.removeAttrs settingsWithoutNulls ["oidc"]
+    else
+      settingsWithoutNulls;
+  settingsFile = settingsFormat.generate "headplane-config.yaml" settingsWithoutEmptyOidc;
 in {
   imports = [./options.nix];
   config = mkIf cfg.enable {


### PR DESCRIPTION
Fixing issue #310 where oidc fields would be auto populated as blank when omitted instead of staying as omitted.