### PR TITLE
Fix ssh wasm admin path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ const config = await readFile('config.example.yaml', 'utf-8');
 const { server } = parse(config);
 
 export default defineConfig(({ isSsrBuild }) => ({
-	base: isSsrBuild ? `${prefix}/` : undefined,
+	base: `${prefix}/`,
 	plugins: [
 		reactRouterHonoServer(),
 		reactRouter(),


### PR DESCRIPTION
## Summary
 - make the Vite client build honor `__INTERNAL_PREFIX` (same as SSR) so every emitted asset URL includes the admin prefix
 - Devs can still override the prefix by exporting `__INTERNAL_PREFIX` before `pnpm dev`

Source comment for issue: https://github.com/tale/headplane/pull/256#issuecomment-3262650281