### PR TITLE
Fix configuration sidebar link

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
 							{ text: 'Docker', link: '/install/docker' },
 						],
 					},
-					{ text: 'Configuration', link: '/Configuration' },
+					{ text: 'Configuration', link: '/configuration' },
 					{ text: 'Nix', link: '/Nix' },
 					{ text: 'NixOS', link: '/NixOS-options' },
 					{


### PR DESCRIPTION
Since sidebar links are case sensitive and the file is named all lower case, the `Configuration` link did not work.