### PR TITLE
fix: write_ahead_log in sqlite config schema

### DIFF
--- a/app/server/headscale/config-schema.ts
+++ b/app/server/headscale/config-schema.ts
@@ -14,7 +14,7 @@ const databaseConfig = type({
 	type: '"sqlite" | "sqlite3"',
 	sqlite: {
 		path: 'string',
-		write_head_log: goBool.default(true),
+		write_ahead_log: goBool.default(true),
 		wal_autocheckpoint: 'number = 1000',
 	},
 })


### PR DESCRIPTION
While investigating some "Error validating Headscale configuration" errors in Headplane packaged for YunoHost, I saw what I think is a typo: `write_head_log` is actually `write_ahead_log` (cf. https://github.com/juanfont/headscale/blob/19a33394f6e0924e2fb63d2d68ad38d5c61b6630/config-example.yaml#L170)