### PR TITLE
Update default dns_records_path in config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -66,7 +66,7 @@ headscale:
   # readable and writable to the Headplane process.
   # When using this, Headplane will no longer need to automatically
   # restart Headscale for DNS record changes.
-  # dns_records_path: "/var/lib/headplane/extra_records.json"
+  # dns_records_path: "/var/lib/headscale/extra_records.json"
 
 # Integration configurations for Headplane to interact with Headscale
 integration:


### PR DESCRIPTION
The example path looked for Headscale's `extra_records.json` file in `/var/lib/headplane`, not `/var/lib/headscale`.