### PR TITLE
fix(docker): bump docker api version to v1.44

### DIFF
--- a/app/server/config/integration/docker.ts
+++ b/app/server/config/integration/docker.ts
@@ -94,7 +94,7 @@ export default class DockerIntegration extends Integration<T> {
 
 			try {
 				log.info('config', 'Checking API: %s', fetchU);
-				await fetch(new URL('/v1.30/version', fetchU).href);
+				await fetch(new URL('/v1.44/version', fetchU).href);
 			} catch (error) {
 				log.error('config', 'Failed to connect to Docker API: %s', error);
 				log.debug('config', 'Connection error: %o', error);
@@ -140,7 +140,7 @@ export default class DockerIntegration extends Integration<T> {
 		);
 		const res = await this.client.request({
 			method: 'GET',
-			path: `/v1.30/containers/json?${qp.toString()}`,
+			path: `/v1.44/containers/json?${qp.toString()}`,
 		});
 
 		if (res.statusCode !== 200) {
@@ -211,7 +211,7 @@ export default class DockerIntegration extends Integration<T> {
 
 			const response = await this.client.request({
 				method: 'POST',
-				path: `/v1.30/containers/${this.containerId}/restart`,
+				path: `/v1.44/containers/${this.containerId}/restart`,
 			});
 
 			if (response.statusCode !== 204) {


### PR DESCRIPTION
This PR resolves #368

Newer versions of docker dropped support for the v1.30 API version. This PR just changes the referenced API version in [app/server/config/integration/docker.ts](https://github.com/tale/headplane/blob/main/app/server/config/integration/docker.ts) from v1.30 to v1.44, as the API spec itself hasn't changed. I chose v1.44 instead of the latest v1.52 for wider support.

## Logs before changes
```
headplane  | 2025-11-21T21:01:20.549Z [config] ERROR: Could not request available Docker containers
headplane  | 2025-11-21T21:01:20.551Z [config] ERROR: Integration Docker is not available
```

## Logs after changes
```headplane  | 2025-11-21T21:25:09.265Z [config] INFO: Using Docker integration
headplane  | 2025-11-21T21:25:09.268Z [config] INFO: Checking socket: /var/run/docker.sock
headplane  | 2025-11-21T21:25:10.355Z [config] INFO: Using container: /headscale (ID: 347920f5fbc603b8325dc2e47e46eaeda990bf62de82ffd719b86ad49cb2a66a)
```