### PR TITLE
fix: accept the full discovered oidc configuration

### DIFF
--- a/app/server/web/oidc-connector.ts
+++ b/app/server/web/oidc-connector.ts
@@ -200,6 +200,7 @@ async function discoveryCoalesce(
 
 	const oidcClient = new oidc.Configuration(
 		{
+			...metadata,
 			issuer: config.issuer,
 			authorization_endpoint,
 			token_endpoint,


### PR DESCRIPTION
Hi @tale, thanks for headplane!

On lastest `main` I got an oauth2 redirect loop. My oauth2 provider is `kanidm` and by debugging using something very similar to https://github.com/tale/headplane/pull/384 I found out it is because by default `kanidm` only supports `ES256` JWS signature alg, which headplane refuses. The actual exception was:
```
OperationProcessingError: unexpected JWT "alg" header parameter
    at OPE (file:///opt/headplane/build/server/assets/index-BgoO6cJe.js:6476:9)
    at checkSigningAlgorithm (file:///opt/headplane/build/server/assets/index-BgoO6cJe.js:7119:159)
    at validateJwt (file:///opt/headplane/build/server/assets/index-BgoO6cJe.js:7049:2)
    at processGenericAccessTokenResponse (file:///opt/headplane/build/server/assets/index-BgoO6cJe.js:6873:33)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async processAuthorizationCodeOpenIDResponse (file:///opt/headplane/build/server/assets/index-BgoO6cJe.js:6983:17)
    at async authorizationCodeGrant (file:///opt/headplane/build/server/assets/index-BgoO6cJe.js:8875:12)
    at async loader$14 (file:///opt/headplane/build/server/assets/node-yAUGHSmu.js:37385:18)
    at async callRouteHandler (file:///opt/headplane/build/server/assets/index-BgoO6cJe.js:5670:15)
    at async commonRoute.loader (file:///opt/headplane/build/server/assets/index-BgoO6cJe.js:5769:12) {
  code: 'OAUTH_INVALID_RESPONSE',
  [cause]: [Object]
}
```

It is easy to fix this on the kanidm side as they have a switch to [enable legacy crypto](https://kanidm.github.io/kanidm/master/integrations/oauth2.html?highlight=legacy#extended-options-for-legacy-clients) which will emit `RS256` signatures which are accepted.

However it is also easy to fix on the headplane side, as `openid-client` fully supports `ES256`. The bug actually comes from the fact that headplane throws out all the optional items of the auto-discovered server config, and that the default config only accepts `RS256` (as can be seen in [`processGenericAccessTokenResponse`](https://github.com/panva/oauth4webapi/blob/e54b4c12498f9025cd01180e7b5407fa719e7e76/src/index.ts#L3630)).

For now I did the most lightweight fix possible, but maybe we should rework a bit the logic in `discoveryCoalesce`? It looks a bit too complicated for what it does.. I'd guess most oauth2 provider actualy have a working auto-discovery, perhaps we could remove all of the manual config (`authorization_endpoint`, `token_endpoint`, `userinfo_endpoint` as well as `use_pkce`).