### PR TITLE
Update OIDC callback URL in SSO documentation

### DIFF
--- a/docs/features/sso.md
+++ b/docs/features/sso.md
@@ -53,7 +53,7 @@ domain is replaced with the value set for `server.base_url` in your Headplane
 configuration:
 
 ```
-https://headplane.example.com/admin/auth/callback
+https://headplane.example.com/admin/oidc/callback
 ```
 
 Once you have created the client in your IdP, make note of the following


### PR DESCRIPTION
Update the redirect URL in the documentation to reflect the actual redirect URI that was actually given to OIDC.

https://github.com/tale/headplane/blob/985d7d9dc6636a7472262dcdc0192642e8f7fd4e/app/routes/auth/oidc-start.ts#L51-L69