### PR TITLE
feat: nix options allow freeform typing

### DIFF
--- a/nix/options.nix
+++ b/nix/options.nix
@@ -10,6 +10,8 @@
     mkPackageOption
     types
     ;
+
+ settingsFormat = pkgs.formats.yaml { };
 in {
   options.services.headplane = {
     enable = mkEnableOption "headplane";
@@ -27,6 +29,8 @@ in {
         See: https://github.com/tale/headplane/blob/main/config.example.yaml
       '';
       type = types.submodule {
+        freeformType = settingsFormat.type;
+
         options = {
           server = mkOption {
             type = types.submodule {


### PR DESCRIPTION
Allows freeform typing, e.g. right now the module options is not updated for the v0.6.2-beta.3, which means it's kind of hard to use. It should have no negative effect, and could potentially lower the maintenance burden. Ie. maybe some options could be removed, and just let the user type them in as they see fit?