### PR TITLE
fix(nix): use user specified package for systemd service

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -55,7 +55,7 @@ in {
         Group = config.services.headscale.group;
         StateDirectory = "headplane";
 
-        ExecStart = "${pkgs.headplane}/bin/headplane";
+        ExecStart = "${cfg.package}/bin/headplane";
         Restart = "always";
         RestartSec = 5;
 


### PR DESCRIPTION
the nixos module has an option for the user to specify the package `services.headplane.package` but this isn't honored by the systemd service