### PR TITLE
feat: support tag-only pre-auth keys for Headscale 0.28

### DIFF
--- a/app/routes/settings/auth-keys/actions.ts
+++ b/app/routes/settings/auth-keys/actions.ts
@@ -25,9 +25,17 @@ export async function authKeysAction({ request, context }: Route.ActionArgs) {
 
   switch (action) {
     case "add_preauthkey": {
-      const user = formData.get("user_id")?.toString();
-      if (!user) {
-        return data("Missing `user_id` in the form data.", {
+      const user = formData.get("user_id")?.toString() || null;
+      const aclTagsRaw = formData.get("acl_tags")?.toString() || "";
+
+      const aclTags = aclTagsRaw
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+
+      // Must have either a user or tags
+      if (!user && aclTags.length === 0) {
+        return data("Must specify either a user or ACL tags.", {
           status: 400,
         });
       }
@@ -53,17 +61,16 @@ export async function authKeysAction({ request, context }: Route.ActionArgs) {
         });
       }
 
-      // Extract the first "word" from expiry which is the day number
-      // Calculate the date X days from now using the day number
       const day = Number(expiry.toString().split(" ")[0]);
       const date = new Date();
       date.setDate(date.getDate() + day);
+
       const key = await api.createPreAuthKey(
         user,
         ephemeral === "on",
         reusable === "on",
         date,
-        [], // TODO
+        aclTags.length > 0 ? aclTags : null,
       );
 
       return data({ success: true as const, key: key.key });

--- a/app/routes/settings/auth-keys/dialogs/add-auth-key.tsx
+++ b/app/routes/settings/auth-keys/dialogs/add-auth-key.tsx
@@ -6,6 +6,7 @@ import type { User } from "~/types";
 import Button from "~/components/Button";
 import Code from "~/components/Code";
 import Dialog from "~/components/Dialog";
+import Input from "~/components/Input";
 import Link from "~/components/Link";
 import NumberInput from "~/components/NumberInput";
 import Select from "~/components/Select";
@@ -23,7 +24,9 @@ export default function AddAuthKey({ users, url }: AddAuthKeyProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [reusable, setReusable] = useState(false);
   const [ephemeral, setEphemeral] = useState(false);
+  const [useTagsOnly, setUseTagsOnly] = useState(false);
   const [userId, setUserId] = useState<Key | null>(users[0]?.id);
+  const [tags, setTags] = useState("");
 
   const createdKey = fetcher.data?.success ? fetcher.data.key : null;
 
@@ -37,10 +40,20 @@ export default function AddAuthKey({ users, url }: AddAuthKeyProps) {
     if (!isOpen) {
       setReusable(false);
       setEphemeral(false);
+      setUseTagsOnly(false);
       setUserId(users[0]?.id);
+      setTags("");
       fetcher.data = undefined;
     }
   }, [isOpen]);
+
+  const parsedTags = tags
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+    .map((t) => (t.startsWith("tag:") ? t : `tag:${t}`));
+
+  const canSubmit = useTagsOnly ? parsedTags.length > 0 : userId != null;
 
   return (
     <Dialog
@@ -84,30 +97,57 @@ export default function AddAuthKey({ users, url }: AddAuthKeyProps) {
             submittingRef.current = true;
             const form = new FormData(event.currentTarget as HTMLFormElement);
             form.set("action_id", "add_preauthkey");
-            form.set("user_id", userId?.toString() ?? "");
+            form.set("user_id", useTagsOnly ? "" : (userId?.toString() ?? ""));
             form.set("reusable", reusable ? "on" : "off");
             form.set("ephemeral", ephemeral ? "on" : "off");
+            form.set("acl_tags", parsedTags.join(","));
             fetcher.submit(form, { method: "POST" });
           }}
-          isDisabled={fetcher.state !== "idle"}
+          isDisabled={fetcher.state !== "idle" || !canSubmit}
         >
           <Dialog.Title>Generate auth key</Dialog.Title>
-          <Select
+
+          <div className="mb-4 flex items-center justify-between gap-2">
+            <div>
+              <Dialog.Text className="font-semibold">Tag-only key</Dialog.Text>
+              <Dialog.Text className="text-sm">
+                Create a key owned by ACL tags instead of a user.
+              </Dialog.Text>
+            </div>
+            <Switch
+              defaultSelected={useTagsOnly}
+              label="Tag-only"
+              onChange={() => setUseTagsOnly(!useTagsOnly)}
+            />
+          </div>
+
+          {!useTagsOnly && (
+            <Select
+              className="mb-2"
+              description="Machines will belong to this user when they authenticate."
+              isRequired
+              label="User"
+              onSelectionChange={(value) => setUserId(value)}
+              placeholder="Select a user"
+            >
+              {users.map((user) => (
+                <Select.Item key={user.id}>
+                  {user.name || user.displayName || user.email || user.id}
+                </Select.Item>
+              ))}
+            </Select>
+          )}
+
+          <Input
             className="mb-2"
-            description="This is the user machines will belong to when they authenticate."
-            isRequired
-            label="User"
-            onSelectionChange={(value) => {
-              setUserId(value);
-            }}
-            placeholder="Select a user"
-          >
-            {users.map((user) => (
-              <Select.Item key={user.id}>
-                {user.name || user.displayName || user.email || user.id}
-              </Select.Item>
-            ))}
-          </Select>
+            description="Comma-separated ACL tags (e.g. server, prod). Prefix 'tag:' is added automatically."
+            isRequired={useTagsOnly}
+            label="ACL Tags"
+            onChange={(value) => setTags(value)}
+            placeholder="server, prod"
+            value={tags}
+          />
+
           <NumberInput
             defaultValue={90}
             description="Set this key to expire after a certain number of days."
@@ -132,9 +172,7 @@ export default function AddAuthKey({ users, url }: AddAuthKeyProps) {
             <Switch
               defaultSelected={reusable}
               label="Reusable"
-              onChange={() => {
-                setReusable(!reusable);
-              }}
+              onChange={() => setReusable(!reusable)}
             />
           </div>
           <div className="mt-6 flex items-center justify-between gap-2">
@@ -154,9 +192,7 @@ export default function AddAuthKey({ users, url }: AddAuthKeyProps) {
             <Switch
               defaultSelected={ephemeral}
               label="Ephemeral"
-              onChange={() => {
-                setEphemeral(!ephemeral);
-              }}
+              onChange={() => setEphemeral(!ephemeral)}
             />
           </div>
         </Dialog.Panel>

--- a/app/server/headscale/api/endpoints/pre-auth-keys.ts
+++ b/app/server/headscale/api/endpoints/pre-auth-keys.ts
@@ -1,69 +1,66 @@
-import type { PreAuthKey } from '~/types';
-import { defineApiEndpoints } from '../factory';
+import type { PreAuthKey } from "~/types";
+
+import { defineApiEndpoints } from "../factory";
 
 export interface PreAuthKeyEndpoints {
-	/**
-	 * Retrieves all pre-authentication keys for a specific user.
-	 *
-	 * @param user The user to retrieve pre-authentication keys for.
-	 * @returns An array of `PreAuthKey` objects representing the pre-authentication keys.
-	 */
-	getPreAuthKeys(user: string): Promise<PreAuthKey[]>;
+  /**
+   * Retrieves all pre-authentication keys for a specific user.
+   */
+  getPreAuthKeys(user: string): Promise<PreAuthKey[]>;
 
-	/**
-	 * Creates a new pre-authentication key for a specific user.
-	 *
-	 * @param user The user to create the pre-authentication key for.
-	 * @param ephemeral Whether the key is ephemeral.
-	 * @param reusable Whether the key is reusable.
-	 * @param expiration The expiration date of the key, or `null` for no expiration.
-	 * @param aclTags An array of ACL tags to associate with the key, or `null` for none.
-	 * @returns A `PreAuthKey` object representing the newly created pre-authentication key.
-	 */
-	createPreAuthKey(
-		user: string,
-		ephemeral: boolean,
-		reusable: boolean,
-		expiration: Date | null,
-		aclTags: string[] | null,
-	): Promise<PreAuthKey>;
+  /**
+   * Creates a new pre-authentication key.
+   * Either user or aclTags must be provided (Headscale 0.28+).
+   */
+  createPreAuthKey(
+    user: string | null,
+    ephemeral: boolean,
+    reusable: boolean,
+    expiration: Date | null,
+    aclTags: string[] | null,
+  ): Promise<PreAuthKey>;
 
-	/**
-	 * Expires a specific pre-authentication key for a user.
-	 *
-	 * @param user The user associated with the pre-authentication key.
-	 * @param key The pre-authentication key to expire.
-	 */
-	expirePreAuthKey(user: string, key: string): Promise<void>;
+  /**
+   * Expires a specific pre-authentication key for a user.
+   */
+  expirePreAuthKey(user: string, key: string): Promise<void>;
 }
 
 export default defineApiEndpoints<PreAuthKeyEndpoints>((client, apiKey) => ({
-	getPreAuthKeys: async (user) => {
-		const { preAuthKeys } = await client.apiFetch<{
-			preAuthKeys: PreAuthKey[];
-		}>('GET', 'v1/preauthkey', apiKey, { user });
+  getPreAuthKeys: async (user) => {
+    const { preAuthKeys } = await client.apiFetch<{
+      preAuthKeys: PreAuthKey[];
+    }>("GET", "v1/preauthkey", apiKey, { user });
 
-		return preAuthKeys;
-	},
+    return preAuthKeys;
+  },
 
-	createPreAuthKey: async (user, ephemeral, reusable, expiration, aclTags) => {
-		const { preAuthKey } = await client.apiFetch<{
-			preAuthKey: PreAuthKey;
-		}>('POST', 'v1/preauthkey', apiKey, {
-			user,
-			ephemeral,
-			reusable,
-			expiration: expiration ? expiration.toISOString() : null,
-			aclTags,
-		});
+  createPreAuthKey: async (user, ephemeral, reusable, expiration, aclTags) => {
+    const body: Record<string, unknown> = {
+      ephemeral,
+      reusable,
+      expiration: expiration ? expiration.toISOString() : null,
+    };
 
-		return preAuthKey;
-	},
+    if (user) {
+      body.user = user;
+    }
 
-	expirePreAuthKey: async (user, key) => {
-		await client.apiFetch<void>('POST', 'v1/preauthkey/expire', apiKey, {
-			user,
-			key,
-		});
-	},
+    if (aclTags && aclTags.length > 0) {
+      body.aclTags = aclTags;
+    }
+
+    const { preAuthKey } = await client.apiFetch<{
+      preAuthKey: PreAuthKey;
+    }>("POST", "v1/preauthkey", apiKey, body);
+
+    return preAuthKey;
+  },
+
+  expirePreAuthKey: async (user, key) => {
+    await client.apiFetch<void>("POST", "v1/preauthkey/expire", apiKey, {
+      user,
+      key,
+    });
+  },
 }));


### PR DESCRIPTION
## Summary

This PR adds support for pre-auth keys owned by ACL tags instead of users, which is a new feature in Headscale 0.28.0.

## Changes

- **UI**: Added a "Tag-only key" toggle in the create pre-auth key dialog
- **UI**: Added ACL tags input field with automatic `tag:` prefix handling
- **UI**: Made user selection conditional (hidden when tag-only mode is enabled)
- **Backend**: Updated action handler to support optional user parameter
- **Backend**: Added validation to ensure either user or ACL tags is provided
- **API**: Updated `createPreAuthKey` endpoint to conditionally include user/aclTags in request body

## How it works

In Headscale 0.28+, pre-auth keys can be:
1. **User-owned** (traditional): Associated with a specific user, optionally with ACL tags
2. **Tag-only** (new): Owned by ACL tags without a user association

When creating a tag-only key:
- Toggle "Tag-only key" switch
- Enter comma-separated ACL tags (e.g., `server, prod`)
- The `tag:` prefix is added automatically if not present

## Testing

1. Open Settings > Auth Keys
2. Click "Create pre-auth key"
3. Toggle "Tag-only key" to create a tag-owned key
4. Verify user selection is hidden and tags are required
5. Create the key and verify it works with Headscale 0.28+

Fixes #432