### PR TITLE
add tag-only preauth keys for headscale 0.28

### DIFF
--- a/app/routes/settings/auth-keys/actions.ts
+++ b/app/routes/settings/auth-keys/actions.ts
@@ -25,9 +25,15 @@ export async function authKeysAction({ request, context }: Route.ActionArgs) {
 
   switch (action) {
     case "add_preauthkey": {
-      const user = formData.get("user_id")?.toString();
-      if (!user) {
-        return data("Missing `user_id` in the form data.", {
+      const user = formData.get("user_id")?.toString() || null;
+      const aclTagsRaw = formData.get("acl_tags")?.toString() || "";
+      const aclTags = aclTagsRaw
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+
+      if (!user && aclTags.length === 0) {
+        return data("Must specify either a user or ACL tags.", {
           status: 400,
         });
       }
@@ -53,17 +59,16 @@ export async function authKeysAction({ request, context }: Route.ActionArgs) {
         });
       }
 
-      // Extract the first "word" from expiry which is the day number
-      // Calculate the date X days from now using the day number
       const day = Number(expiry.toString().split(" ")[0]);
       const date = new Date();
       date.setDate(date.getDate() + day);
+
       const key = await api.createPreAuthKey(
         user,
         ephemeral === "on",
         reusable === "on",
         date,
-        [], // TODO
+        aclTags.length > 0 ? aclTags : null,
       );
 
       return data({ success: true as const, key: key.key });

--- a/app/server/headscale/api/endpoints/pre-auth-keys.ts
+++ b/app/server/headscale/api/endpoints/pre-auth-keys.ts
@@ -1,69 +1,72 @@
-import type { PreAuthKey } from '~/types';
-import { defineApiEndpoints } from '../factory';
+import type { PreAuthKey } from "~/types";
+
+import { defineApiEndpoints } from "../factory";
 
 export interface PreAuthKeyEndpoints {
-	/**
-	 * Retrieves all pre-authentication keys for a specific user.
-	 *
-	 * @param user The user to retrieve pre-authentication keys for.
-	 * @returns An array of `PreAuthKey` objects representing the pre-authentication keys.
-	 */
-	getPreAuthKeys(user: string): Promise<PreAuthKey[]>;
+  /**
+   * Retrieves all pre-authentication keys for a specific user.
+   *
+   * @param user The user to retrieve pre-authentication keys for.
+   * @returns An array of `PreAuthKey` objects representing the pre-authentication keys.
+   */
+  getPreAuthKeys(user: string): Promise<PreAuthKey[]>;
 
-	/**
-	 * Creates a new pre-authentication key for a specific user.
-	 *
-	 * @param user The user to create the pre-authentication key for.
-	 * @param ephemeral Whether the key is ephemeral.
-	 * @param reusable Whether the key is reusable.
-	 * @param expiration The expiration date of the key, or `null` for no expiration.
-	 * @param aclTags An array of ACL tags to associate with the key, or `null` for none.
-	 * @returns A `PreAuthKey` object representing the newly created pre-authentication key.
-	 */
-	createPreAuthKey(
-		user: string,
-		ephemeral: boolean,
-		reusable: boolean,
-		expiration: Date | null,
-		aclTags: string[] | null,
-	): Promise<PreAuthKey>;
+  /**
+   * Creates a new pre-authentication key.
+   * User can be null for tag-only keys (requires Headscale 0.28+).
+   */
+  createPreAuthKey(
+    user: string | null,
+    ephemeral: boolean,
+    reusable: boolean,
+    expiration: Date | null,
+    aclTags: string[] | null,
+  ): Promise<PreAuthKey>;
 
-	/**
-	 * Expires a specific pre-authentication key for a user.
-	 *
-	 * @param user The user associated with the pre-authentication key.
-	 * @param key The pre-authentication key to expire.
-	 */
-	expirePreAuthKey(user: string, key: string): Promise<void>;
+  /**
+   * Expires a specific pre-authentication key for a user.
+   *
+   * @param user The user associated with the pre-authentication key.
+   * @param key The pre-authentication key to expire.
+   */
+  expirePreAuthKey(user: string, key: string): Promise<void>;
 }
 
 export default defineApiEndpoints<PreAuthKeyEndpoints>((client, apiKey) => ({
-	getPreAuthKeys: async (user) => {
-		const { preAuthKeys } = await client.apiFetch<{
-			preAuthKeys: PreAuthKey[];
-		}>('GET', 'v1/preauthkey', apiKey, { user });
+  getPreAuthKeys: async (user) => {
+    const { preAuthKeys } = await client.apiFetch<{
+      preAuthKeys: PreAuthKey[];
+    }>("GET", "v1/preauthkey", apiKey, { user });
 
-		return preAuthKeys;
-	},
+    return preAuthKeys;
+  },
 
-	createPreAuthKey: async (user, ephemeral, reusable, expiration, aclTags) => {
-		const { preAuthKey } = await client.apiFetch<{
-			preAuthKey: PreAuthKey;
-		}>('POST', 'v1/preauthkey', apiKey, {
-			user,
-			ephemeral,
-			reusable,
-			expiration: expiration ? expiration.toISOString() : null,
-			aclTags,
-		});
+  createPreAuthKey: async (user, ephemeral, reusable, expiration, aclTags) => {
+    const body: Record<string, unknown> = {
+      ephemeral,
+      reusable,
+      expiration: expiration ? expiration.toISOString() : null,
+    };
 
-		return preAuthKey;
-	},
+    if (user) {
+      body.user = user;
+    }
 
-	expirePreAuthKey: async (user, key) => {
-		await client.apiFetch<void>('POST', 'v1/preauthkey/expire', apiKey, {
-			user,
-			key,
-		});
-	},
+    if (aclTags && aclTags.length > 0) {
+      body.aclTags = aclTags;
+    }
+
+    const { preAuthKey } = await client.apiFetch<{
+      preAuthKey: PreAuthKey;
+    }>("POST", "v1/preauthkey", apiKey, body);
+
+    return preAuthKey;
+  },
+
+  expirePreAuthKey: async (user, key) => {
+    await client.apiFetch<void>("POST", "v1/preauthkey/expire", apiKey, {
+      user,
+      key,
+    });
+  },
 }));


### PR DESCRIPTION
Adds support for creating preauth keys with ACL tags but no user, which is needed for Headscale 0.28.

Changes:
- Added tag-only toggle in the create key dialog
- ACL tags input with automatic tag: prefix
- User field hidden when tag-only is enabled
- API updated to conditionally include user/tags
- Test for tag-only keys (skipped on <0.28)

Fixes #432