### PR TITLE
list preauth keys without user filter (0.28+)

### DIFF
--- a/app/routes/settings/auth-keys/auth-key-row.tsx
+++ b/app/routes/settings/auth-keys/auth-key-row.tsx
@@ -6,23 +6,26 @@ import ExpireAuthKey from "./dialogs/expire-auth-key";
 
 interface Props {
   authKey: PreAuthKey;
-  user: User;
+  user: User | null;
 }
 
 export default function AuthKeyRow({ authKey, user }: Props) {
   const createdAt = new Date(authKey.createdAt).toLocaleString();
   const expiration = new Date(authKey.expiration).toLocaleString();
+  const isExpired =
+    (authKey.used && !authKey.reusable) || new Date(authKey.expiration) < new Date();
+  const userDisplay = user ? user.name || user.displayName || user.email || user.id : "(Tag Only)";
 
   return (
     <div className="w-full">
       <Attribute name="Key" value={authKey.key} />
-      <Attribute name="User" value={user.name || user.displayName || user.email || user.id} />
+      <Attribute name="User" value={userDisplay} />
       <Attribute name="Reusable" value={authKey.reusable ? "Yes" : "No"} />
       <Attribute name="Ephemeral" value={authKey.ephemeral ? "Yes" : "No"} />
       <Attribute name="Used" value={authKey.used ? "Yes" : "No"} />
       <Attribute name="Created" value={createdAt} />
       <Attribute name="Expiration" value={expiration} />
-      {!((authKey.used && !authKey.reusable) || new Date(authKey.expiration) < new Date()) && (
+      {!isExpired && user && (
         <div className="mt-2" suppressHydrationWarning>
           <ExpireAuthKey authKey={authKey} user={user} />
         </div>

--- a/app/server/headscale/api/endpoints/pre-auth-keys.ts
+++ b/app/server/headscale/api/endpoints/pre-auth-keys.ts
@@ -4,6 +4,11 @@ import { defineApiEndpoints } from "../factory";
 
 export interface PreAuthKeyEndpoints {
   /**
+   * List all pre-auth keys. Requires Headscale 0.28+.
+   */
+  getAllPreAuthKeys(): Promise<PreAuthKey[]>;
+
+  /**
    * Retrieves all pre-authentication keys for a specific user.
    *
    * @param user The user to retrieve pre-authentication keys for.
@@ -33,6 +38,14 @@ export interface PreAuthKeyEndpoints {
 }
 
 export default defineApiEndpoints<PreAuthKeyEndpoints>((client, apiKey) => ({
+  getAllPreAuthKeys: async () => {
+    const { preAuthKeys } = await client.apiFetch<{
+      preAuthKeys: PreAuthKey[];
+    }>("GET", "v1/preauthkey", apiKey, {});
+
+    return preAuthKeys;
+  },
+
   getPreAuthKeys: async (user) => {
     const { preAuthKeys } = await client.apiFetch<{
       preAuthKeys: PreAuthKey[];

--- a/app/types/PreAuthKey.ts
+++ b/app/types/PreAuthKey.ts
@@ -3,7 +3,7 @@ import type { User } from './User';
 export interface PreAuthKey {
 	id: string;
 	key: string;
-	user: User;
+	user: User | null;
 	reusable: boolean;
 	ephemeral: boolean;
 	used: boolean;

--- a/tests/integration/pre-auth-keys.test.ts
+++ b/tests/integration/pre-auth-keys.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { getBootstrapClient, getRuntimeClient, HS_VERSIONS } from "./setup/env";
+import { getBootstrapClient, getIsAtLeast, getRuntimeClient, HS_VERSIONS } from "./setup/env";
 
 describe.sequential.for(HS_VERSIONS)("Headscale %s: Pre-auth Keys", (version) => {
   test("pre-auth keys can be created", async () => {
@@ -13,7 +13,7 @@ describe.sequential.for(HS_VERSIONS)("Headscale %s: Pre-auth Keys", (version) =>
     const preAuthKey = await client.createPreAuthKey(preAuthKeyUser.id, false, false, expiry, null);
 
     expect(preAuthKey).toBeDefined();
-    expect(preAuthKey.user.id).toBe(preAuthKeyUser.id);
+    expect(preAuthKey.user?.id).toBe(preAuthKeyUser.id);
     expect(preAuthKey.ephemeral).toBe(false);
     expect(preAuthKey.reusable).toBe(false);
     expect(preAuthKey.aclTags).toEqual([]);
@@ -30,7 +30,7 @@ describe.sequential.for(HS_VERSIONS)("Headscale %s: Pre-auth Keys", (version) =>
     const preAuthKey = await client.createPreAuthKey(preAuthKeyUser.id, true, true, null, aclTags);
 
     expect(preAuthKey).toBeDefined();
-    expect(preAuthKey.user.id).toBe(preAuthKeyUser.id);
+    expect(preAuthKey.user?.id).toBe(preAuthKeyUser.id);
     expect(preAuthKey.ephemeral).toBe(true);
     expect(preAuthKey.reusable).toBe(true);
     expect(preAuthKey.aclTags.sort()).toEqual(aclTags.sort());
@@ -62,6 +62,47 @@ describe.sequential.for(HS_VERSIONS)("Headscale %s: Pre-auth Keys", (version) =>
     const preAuthKeys = await client.getPreAuthKeys(preAuthKeyUser.id);
     expect(Array.isArray(preAuthKeys)).toBe(true);
     expect(preAuthKeys.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("all pre-auth keys can be listed without user filter (0.28+)", async (context) => {
+    const isAtLeast = await getIsAtLeast(version);
+    if (!isAtLeast("0.28.0")) {
+      context.skip();
+    }
+
+    const client = await getRuntimeClient(version);
+    const [preAuthKeyUser] = await client.getUsers(undefined, "preauthkeyuser@");
+    expect(preAuthKeyUser).toBeDefined();
+
+    const allKeys = await client.getAllPreAuthKeys();
+    expect(Array.isArray(allKeys)).toBe(true);
+    expect(allKeys.length).toBeGreaterThanOrEqual(2);
+
+    const userSpecificKeys = await client.getPreAuthKeys(preAuthKeyUser.id);
+    for (const userKey of userSpecificKeys) {
+      const found = allKeys.find((k) => k.key === userKey.key);
+      expect(found).toBeDefined();
+    }
+  });
+
+  test("getAllPreAuthKeys returns keys with correct structure (0.28+)", async (context) => {
+    const isAtLeast = await getIsAtLeast(version);
+    if (!isAtLeast("0.28.0")) {
+      context.skip();
+    }
+
+    const client = await getRuntimeClient(version);
+    const allKeys = await client.getAllPreAuthKeys();
+
+    for (const key of allKeys) {
+      expect(key.id).toBeDefined();
+      expect(key.key).toBeDefined();
+      expect(typeof key.reusable).toBe("boolean");
+      expect(typeof key.ephemeral).toBe("boolean");
+      expect(typeof key.used).toBe("boolean");
+      expect(key.expiration).toBeDefined();
+      expect(key.createdAt).toBeDefined();
+    }
   });
 
   test("pre-auth keys can be expired", async () => {


### PR DESCRIPTION
adds support for listing all preauth keys including tag-only keys on headscale 0.28+

backward compatible - falls back to per-user fetching on older versions

## changes
- new getAllPreAuthKeys() that calls GET /v1/preauthkey without user param
- loader tries this first, falls back to per-user fetching if it fails
- ui shows "Tag Only" filter when tag-only keys exist
- tag-only keys display "(Tag Only)" instead of username

## testing
- added 3 tests for getAllPreAuthKeys (run on 0.28+ only)
- all tests pass across 0.26.0, 0.26.1, 0.27.0, 0.27.1, 0.28.0

closes #432