### PR TITLE
Fix pre-auth keys not showing for OIDC users without username

### DIFF
--- a/app/utils/user.ts
+++ b/app/utils/user.ts
@@ -1,0 +1,11 @@
+import type { User } from "~/types/User";
+
+// Filter users with valid IDs (OIDC users may not have a name)
+export function filterUsersWithValidIds(users: User[]): User[] {
+  return users.filter((user) => user.id?.length > 0);
+}
+
+// Get display name with fallback: name -> displayName -> email -> id
+export function getUserDisplayName(user: User): string {
+  return user.name || user.displayName || user.email || user.id;
+}

--- a/tests/unit/utils/user.test.ts
+++ b/tests/unit/utils/user.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+
+import type { User } from "~/types/User";
+
+import { filterUsersWithValidIds, getUserDisplayName } from "~/utils/user";
+
+const makeUser = (overrides: Partial<User>): User => ({
+  id: "default-id",
+  name: "",
+  createdAt: "2024-01-01T00:00:00Z",
+  ...overrides,
+});
+
+describe("filterUsersWithValidIds", () => {
+  test("keeps users with valid ID and name", () => {
+    const users = [makeUser({ id: "123", name: "John" })];
+    const result = filterUsersWithValidIds(users);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("123");
+  });
+
+  test("keeps users with valid ID but no name", () => {
+    const users = [makeUser({ id: "123", name: "" })];
+    const result = filterUsersWithValidIds(users);
+    expect(result).toHaveLength(1);
+  });
+
+  test("keeps users with valid ID and no optional fields", () => {
+    const users = [makeUser({ id: "123", name: "", displayName: undefined, email: undefined })];
+    const result = filterUsersWithValidIds(users);
+    expect(result).toHaveLength(1);
+  });
+
+  test("removes users with empty ID", () => {
+    const users = [makeUser({ id: "", name: "John" })];
+    const result = filterUsersWithValidIds(users);
+    expect(result).toHaveLength(0);
+  });
+
+  test("handles mix of valid and invalid", () => {
+    const users = [
+      makeUser({ id: "123", name: "John" }),
+      makeUser({ id: "", name: "Jane" }),
+      makeUser({ id: "456", name: "" }),
+    ];
+    const result = filterUsersWithValidIds(users);
+    expect(result).toHaveLength(2);
+    expect(result.map((u) => u.id)).toEqual(["123", "456"]);
+  });
+
+  test("returns empty for empty input", () => {
+    expect(filterUsersWithValidIds([])).toHaveLength(0);
+  });
+});
+
+describe("getUserDisplayName", () => {
+  test("uses name when set", () => {
+    const user = makeUser({ id: "123", name: "John" });
+    expect(getUserDisplayName(user)).toBe("John");
+  });
+
+  test("uses displayName when name is empty", () => {
+    const user = makeUser({ id: "123", name: "", displayName: "John Doe" });
+    expect(getUserDisplayName(user)).toBe("John Doe");
+  });
+
+  test("uses email when name and displayName are empty", () => {
+    const user = makeUser({ id: "123", name: "", displayName: "", email: "john@example.com" });
+    expect(getUserDisplayName(user)).toBe("john@example.com");
+  });
+
+  test("uses id when everything else is empty", () => {
+    const user = makeUser({ id: "123", name: "", displayName: "", email: "" });
+    expect(getUserDisplayName(user)).toBe("123");
+  });
+
+  test("uses id when optional fields are undefined", () => {
+    const user = makeUser({ id: "123", name: "", displayName: undefined, email: undefined });
+    expect(getUserDisplayName(user)).toBe("123");
+  });
+
+  test("prefers name over displayName", () => {
+    const user = makeUser({
+      id: "123",
+      name: "John",
+      displayName: "John Doe",
+      email: "john@example.com",
+    });
+    expect(getUserDisplayName(user)).toBe("John");
+  });
+
+  test("prefers displayName over email", () => {
+    const user = makeUser({
+      id: "123",
+      name: "",
+      displayName: "John Doe",
+      email: "john@example.com",
+    });
+    expect(getUserDisplayName(user)).toBe("John Doe");
+  });
+});


### PR DESCRIPTION
Fixes #459

OIDC users (e.g., Google OIDC) may not have a `name` field populated. The pre-auth keys page was filtering out users where `user.name?.length > 0`, which excluded these users entirely.

**Changes:**
- Changed the user filter to check `user.id` instead of `user.name` since all users have a valid ID
- Updated the error notice to use the same fallback pattern (`name || displayName || email || id`) for displaying user identifiers

This ensures OIDC users without usernames can see and manage their pre-auth keys.