### PR TITLE
fix: return login errors to form instead of throwing

### DIFF
--- a/tests/unit/auth/login-action.test.ts
+++ b/tests/unit/auth/login-action.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test, vi } from "vitest";
+
+// Helper to create a mock FormData with optional api_key
+function mockFormData(apiKey?: string): FormData {
+  const formData = new FormData();
+  if (apiKey !== undefined) {
+    formData.set("api_key", apiKey);
+  }
+  return formData;
+}
+
+// Helper to create mock request
+function mockRequest(formData: FormData): Request {
+  return {
+    formData: () => Promise.resolve(formData),
+  } as unknown as Request;
+}
+
+// Types for test clarity
+interface LoginResult {
+  success: boolean;
+  message: string;
+}
+
+interface MockApiKey {
+  prefix: string;
+  expiration: string | null;
+}
+
+// Mock the log module to avoid console spam during tests
+vi.mock("~/utils/log", () => ({
+  default: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe("Login action validation", () => {
+  test("returns error when api_key field is missing", async () => {
+    const { loginAction } = await import("~/routes/auth/login/action");
+    const formData = mockFormData(); // no api_key
+    const request = mockRequest(formData);
+
+    const mockContext = {
+      hsApi: { getRuntimeClient: vi.fn() },
+      sessions: { createSession: vi.fn() },
+    };
+
+    const result = (await loginAction({
+      request,
+      context: mockContext,
+      params: {},
+    } as any)) as LoginResult;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Missing");
+  });
+
+  test("returns error when api_key is empty string", async () => {
+    const { loginAction } = await import("~/routes/auth/login/action");
+    const formData = mockFormData("");
+    const request = mockRequest(formData);
+
+    const mockContext = {
+      hsApi: { getRuntimeClient: vi.fn() },
+      sessions: { createSession: vi.fn() },
+    };
+
+    const result = (await loginAction({
+      request,
+      context: mockContext,
+      params: {},
+    } as any)) as LoginResult;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("empty");
+  });
+
+  test("returns error when api key not found in database", async () => {
+    const { loginAction } = await import("~/routes/auth/login/action");
+    const formData = mockFormData("some-invalid-key-12345");
+    const request = mockRequest(formData);
+
+    const mockGetApiKeys = vi
+      .fn()
+      .mockResolvedValue([{ prefix: "other-prefix", expiration: "2030-01-01T00:00:00Z" }]);
+
+    const mockContext = {
+      hsApi: {
+        getRuntimeClient: () => ({ getApiKeys: mockGetApiKeys }),
+      },
+      sessions: { createSession: vi.fn() },
+    };
+
+    const result = (await loginAction({
+      request,
+      context: mockContext,
+      params: {},
+    } as any)) as LoginResult;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("not found");
+  });
+
+  test("returns error when api key has expired", async () => {
+    const { loginAction } = await import("~/routes/auth/login/action");
+    const expiredKey = "expired-key-prefix.secret";
+    const formData = mockFormData(expiredKey);
+    const request = mockRequest(formData);
+
+    const mockGetApiKeys = vi
+      .fn()
+      .mockResolvedValue([{ prefix: "expired-key-prefix", expiration: "2020-01-01T00:00:00Z" }]);
+
+    const mockContext = {
+      hsApi: {
+        getRuntimeClient: () => ({ getApiKeys: mockGetApiKeys }),
+      },
+      sessions: { createSession: vi.fn() },
+    };
+
+    const result = (await loginAction({
+      request,
+      context: mockContext,
+      params: {},
+    } as any)) as LoginResult;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("expired");
+  });
+
+  test("returns error when api key has no expiration field", async () => {
+    const { loginAction } = await import("~/routes/auth/login/action");
+    const keyWithoutExpiry = "malformed-key.secret";
+    const formData = mockFormData(keyWithoutExpiry);
+    const request = mockRequest(formData);
+
+    const mockGetApiKeys = vi
+      .fn()
+      .mockResolvedValue([{ prefix: "malformed-key", expiration: null } as MockApiKey]);
+
+    const mockContext = {
+      hsApi: {
+        getRuntimeClient: () => ({ getApiKeys: mockGetApiKeys }),
+      },
+      sessions: { createSession: vi.fn() },
+    };
+
+    const result = (await loginAction({
+      request,
+      context: mockContext,
+      params: {},
+    } as any)) as LoginResult;
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("malformed");
+  });
+
+  test("handles asterisks in api key prefix from headscale 0.28+", async () => {
+    const { loginAction } = await import("~/routes/auth/login/action");
+    const apiKey = "my-key-prefix.the-secret-part";
+    const formData = mockFormData(apiKey);
+    const request = mockRequest(formData);
+
+    const futureDate = new Date();
+    futureDate.setFullYear(futureDate.getFullYear() + 1);
+
+    const mockGetApiKeys = vi
+      .fn()
+      .mockResolvedValue([{ prefix: "my-***-prefix", expiration: futureDate.toISOString() }]);
+
+    const mockCreateSession = vi.fn().mockResolvedValue("session-cookie");
+
+    const mockContext = {
+      hsApi: {
+        getRuntimeClient: () => ({ getApiKeys: mockGetApiKeys }),
+      },
+      sessions: { createSession: mockCreateSession },
+    };
+
+    const result = await loginAction({
+      request,
+      context: mockContext,
+      params: {},
+    } as any);
+
+    // Should match despite asterisks in stored prefix
+    // Result will be a redirect (Response) on success, not our error object
+    expect(result).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #474

## Problem
Users see "Unexpected Server Error" when entering API keys during login. This happens with any input, valid or invalid.

## Cause
React Router v7 changed how `throw data()` works in actions. Instead of returning to the component as `actionData`, it now triggers the ErrorBoundary.

## Solution
Changed validation errors from `throw data()` to `return { success: false, message }`. The form already handles this return type and displays errors correctly.

## Changes
- `app/routes/auth/login/action.ts` - return errors instead of throwing
- `tests/unit/auth/login-action.test.ts` - unit tests for validation scenarios

## Testing
- Added 6 unit tests covering: missing key, empty key, not found, expired, malformed expiration, asterisk handling
- All existing tests pass