### PR TITLE
Add self-service pre-auth keys for auditor role

### DIFF
--- a/app/server/web/roles.ts
+++ b/app/server/web/roles.ts
@@ -1,144 +1,148 @@
 export type Capabilities = (typeof Capabilities)[keyof typeof Capabilities];
 export const Capabilities = {
-	// Can access the admin console
-	ui_access: 1 << 0,
+  // Can access the admin console
+  ui_access: 1 << 0,
 
-	// Read tailnet policy file (unimplemented)
-	read_policy: 1 << 1,
+  // Read tailnet policy file (unimplemented)
+  read_policy: 1 << 1,
 
-	// Write tailnet policy file (unimplemented)
-	write_policy: 1 << 2,
+  // Write tailnet policy file (unimplemented)
+  write_policy: 1 << 2,
 
-	// Read network configurations
-	read_network: 1 << 3,
+  // Read network configurations
+  read_network: 1 << 3,
 
-	// Write network configurations, for example, enable MagicDNS, split DNS,
-	// make subnet, or allow a node to be an exit node, enable HTTPS
-	write_network: 1 << 4,
+  // Write network configurations, for example, enable MagicDNS, split DNS,
+  // make subnet, or allow a node to be an exit node, enable HTTPS
+  write_network: 1 << 4,
 
-	// Read feature configuration (unimplemented)
-	read_feature: 1 << 5,
+  // Read feature configuration (unimplemented)
+  read_feature: 1 << 5,
 
-	// Write feature configuration, for example, enable Taildrop (unimplemented)
-	write_feature: 1 << 6,
+  // Write feature configuration, for example, enable Taildrop (unimplemented)
+  write_feature: 1 << 6,
 
-	// Configure user & group provisioning
-	configure_iam: 1 << 7,
+  // Configure user & group provisioning
+  configure_iam: 1 << 7,
 
-	// Read machines, for example, see machine names and status
-	read_machines: 1 << 8,
+  // Read machines, for example, see machine names and status
+  read_machines: 1 << 8,
 
-	// Write machines, for example, approve, rename, and remove machines
-	write_machines: 1 << 9,
+  // Write machines, for example, approve, rename, and remove machines
+  write_machines: 1 << 9,
 
-	// Read users and user roles
-	read_users: 1 << 10,
+  // Read users and user roles
+  read_users: 1 << 10,
 
-	// Write users and user roles, for example, remove users,
-	// approve users, make Admin
-	write_users: 1 << 11,
+  // Write users and user roles, for example, remove users,
+  // approve users, make Admin
+  write_users: 1 << 11,
 
-	// Can generate authkeys (unimplemented)
-	generate_authkeys: 1 << 12,
+  // Can generate authkeys for any user
+  generate_authkeys: 1 << 12,
 
-	// Can use any tag (without being tag owner) (unimplemented)
-	use_tags: 1 << 13,
+  // Can generate authkeys for own user only
+  generate_own_authkeys: 1 << 16,
 
-	// Write tailnet name (unimplemented)
-	write_tailnet: 1 << 14,
+  // Can use any tag (without being tag owner) (unimplemented)
+  use_tags: 1 << 13,
 
-	// Owner flag
-	owner: 1 << 15,
+  // Write tailnet name (unimplemented)
+  write_tailnet: 1 << 14,
+
+  // Owner flag
+  owner: 1 << 15,
 } as const;
 
 export type Roles = [keyof typeof Roles];
 export const Roles = {
-	owner:
-		Capabilities.ui_access |
-		Capabilities.read_policy |
-		Capabilities.write_policy |
-		Capabilities.read_network |
-		Capabilities.write_network |
-		Capabilities.read_feature |
-		Capabilities.write_feature |
-		Capabilities.configure_iam |
-		Capabilities.read_machines |
-		Capabilities.write_machines |
-		Capabilities.read_users |
-		Capabilities.write_users |
-		Capabilities.generate_authkeys |
-		Capabilities.use_tags |
-		Capabilities.write_tailnet |
-		Capabilities.owner,
+  owner:
+    Capabilities.ui_access |
+    Capabilities.read_policy |
+    Capabilities.write_policy |
+    Capabilities.read_network |
+    Capabilities.write_network |
+    Capabilities.read_feature |
+    Capabilities.write_feature |
+    Capabilities.configure_iam |
+    Capabilities.read_machines |
+    Capabilities.write_machines |
+    Capabilities.read_users |
+    Capabilities.write_users |
+    Capabilities.generate_authkeys |
+    Capabilities.use_tags |
+    Capabilities.write_tailnet |
+    Capabilities.owner,
 
-	admin:
-		Capabilities.ui_access |
-		Capabilities.read_policy |
-		Capabilities.write_policy |
-		Capabilities.read_network |
-		Capabilities.write_network |
-		Capabilities.read_feature |
-		Capabilities.write_feature |
-		Capabilities.configure_iam |
-		Capabilities.read_machines |
-		Capabilities.write_machines |
-		Capabilities.read_users |
-		Capabilities.write_users |
-		Capabilities.generate_authkeys |
-		Capabilities.use_tags |
-		Capabilities.write_tailnet,
+  admin:
+    Capabilities.ui_access |
+    Capabilities.read_policy |
+    Capabilities.write_policy |
+    Capabilities.read_network |
+    Capabilities.write_network |
+    Capabilities.read_feature |
+    Capabilities.write_feature |
+    Capabilities.configure_iam |
+    Capabilities.read_machines |
+    Capabilities.write_machines |
+    Capabilities.read_users |
+    Capabilities.write_users |
+    Capabilities.generate_authkeys |
+    Capabilities.use_tags |
+    Capabilities.write_tailnet,
 
-	network_admin:
-		Capabilities.ui_access |
-		Capabilities.read_policy |
-		Capabilities.write_policy |
-		Capabilities.read_network |
-		Capabilities.write_network |
-		Capabilities.read_feature |
-		Capabilities.read_machines |
-		Capabilities.read_users |
-		Capabilities.generate_authkeys |
-		Capabilities.use_tags |
-		Capabilities.write_tailnet,
+  network_admin:
+    Capabilities.ui_access |
+    Capabilities.read_policy |
+    Capabilities.write_policy |
+    Capabilities.read_network |
+    Capabilities.write_network |
+    Capabilities.read_feature |
+    Capabilities.read_machines |
+    Capabilities.read_users |
+    Capabilities.generate_authkeys |
+    Capabilities.use_tags |
+    Capabilities.write_tailnet,
 
-	it_admin:
-		Capabilities.ui_access |
-		Capabilities.read_policy |
-		Capabilities.read_network |
-		Capabilities.read_feature |
-		Capabilities.write_feature |
-		Capabilities.configure_iam |
-		Capabilities.read_machines |
-		Capabilities.write_machines |
-		Capabilities.read_users |
-		Capabilities.write_users |
-		Capabilities.generate_authkeys,
+  it_admin:
+    Capabilities.ui_access |
+    Capabilities.read_policy |
+    Capabilities.read_network |
+    Capabilities.read_feature |
+    Capabilities.write_feature |
+    Capabilities.configure_iam |
+    Capabilities.read_machines |
+    Capabilities.write_machines |
+    Capabilities.read_users |
+    Capabilities.write_users |
+    Capabilities.generate_authkeys,
 
-	auditor:
-		Capabilities.ui_access |
-		Capabilities.read_policy |
-		Capabilities.read_network |
-		Capabilities.read_feature |
-		Capabilities.read_machines |
-		Capabilities.read_users,
+  auditor:
+    Capabilities.ui_access |
+    Capabilities.read_policy |
+    Capabilities.read_network |
+    Capabilities.read_feature |
+    Capabilities.read_machines |
+    Capabilities.read_users |
+    Capabilities.generate_own_authkeys,
 
-	// Default role for new users with 0 capabilities on the UI side of things
-	member: 0,
+  // Default role for new users with 0 capabilities on the UI side of things
+  member: 0,
 } as const;
 
 export type Role = keyof typeof Roles;
 export type Capability = keyof typeof Capabilities;
 export function hasCapability(role: Role, capability: Capability): boolean {
-	return (Roles[role] & Capabilities[capability]) !== 0;
+  return (Roles[role] & Capabilities[capability]) !== 0;
 }
 
 export function getRoleFromCapabilities(capabilities: Capabilities): Role {
-	const iterable = Roles as Record<string, Capabilities>;
-	for (const role in iterable) {
-		if (iterable[role] === capabilities) {
-			return role as Role;
-		}
-	}
+  const iterable = Roles as Record<string, Capabilities>;
+  for (const role in iterable) {
+    if (iterable[role] === capabilities) {
+      return role as Role;
+    }
+  }
 
-	return 'member';
+  return "member";
 }

--- a/tests/unit/auth-keys/self-service.test.ts
+++ b/tests/unit/auth-keys/self-service.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+
+import { Capabilities, hasCapability, Roles } from "~/server/web/roles";
+
+describe("Self-service pre-auth keys", () => {
+  describe("Capabilities", () => {
+    test("generate_own_authkeys capability exists", () => {
+      expect(Capabilities.generate_own_authkeys).toBeDefined();
+      expect(typeof Capabilities.generate_own_authkeys).toBe("number");
+    });
+
+    test("generate_own_authkeys is distinct from generate_authkeys", () => {
+      expect(Capabilities.generate_own_authkeys).not.toBe(Capabilities.generate_authkeys);
+    });
+  });
+
+  describe("Auditor role", () => {
+    test("auditor has generate_own_authkeys", () => {
+      expect(hasCapability("auditor", "generate_own_authkeys")).toBe(true);
+    });
+
+    test("auditor does not have generate_authkeys", () => {
+      expect(hasCapability("auditor", "generate_authkeys")).toBe(false);
+    });
+
+    test("auditor has read permissions", () => {
+      expect(hasCapability("auditor", "read_machines")).toBe(true);
+      expect(hasCapability("auditor", "read_users")).toBe(true);
+      expect(hasCapability("auditor", "read_policy")).toBe(true);
+    });
+  });
+
+  describe("Admin roles retain full access", () => {
+    test("owner has generate_authkeys", () => {
+      expect(hasCapability("owner", "generate_authkeys")).toBe(true);
+    });
+
+    test("admin has generate_authkeys", () => {
+      expect(hasCapability("admin", "generate_authkeys")).toBe(true);
+    });
+
+    test("it_admin has generate_authkeys", () => {
+      expect(hasCapability("it_admin", "generate_authkeys")).toBe(true);
+    });
+
+    test("network_admin has generate_authkeys", () => {
+      expect(hasCapability("network_admin", "generate_authkeys")).toBe(true);
+    });
+  });
+
+  describe("Member role", () => {
+    test("member has no capabilities", () => {
+      expect(Roles.member).toBe(0);
+    });
+
+    test("member does not have generate_own_authkeys", () => {
+      expect(hasCapability("member", "generate_own_authkeys")).toBe(false);
+    });
+  });
+});
+
+describe("providerId subject extraction", () => {
+  function extractSubject(providerId: string | undefined): string | undefined {
+    return providerId?.split("/").pop();
+  }
+
+  test("extracts subject from oidc providerId", () => {
+    expect(extractSubject("oidc/abc123")).toBe("abc123");
+  });
+
+  test("extracts subject from nested providerId", () => {
+    expect(extractSubject("provider/tenant/user123")).toBe("user123");
+  });
+
+  test("handles single component providerId", () => {
+    expect(extractSubject("subject")).toBe("subject");
+  });
+
+  test("returns undefined for undefined providerId", () => {
+    expect(extractSubject(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #453

Auditors can now create pre-auth keys for their own user account. The user dropdown is locked to their account and tag-only keys are disabled for self-service users.

Changes:
- Added `generate_own_authkeys` capability to auditor role
- Server-side validation ensures auditors can only create keys for themselves
- UI locks user selection in self-service mode
- Added unit tests

<img width="779" height="713" alt="headplane-1" src="https://github.com/user-attachments/assets/2d934708-3778-4816-96aa-78e97e5c9d3d" />

<img width="722" height="656" alt="headplane-2" src="https://github.com/user-attachments/assets/9d6aea7c-90ad-4c58-955e-d59f8c663d03" />
