### PR TITLE
Fix link to Headplane configuration file in docker.md

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -17,7 +17,7 @@ with Docker.
 ## Prerequisites
 - Docker and Docker Compose
 - Headscale version 0.26.0 or later installed and running
-- A [completed configuration file](/index.md#configuration) for Headplane. 
+- A [completed configuration file](/docker.md#configuration) for Headplane. 
 
 
 ## Installation


### PR DESCRIPTION
Updated the link to the completed configuration file for Headplane in the Docker installation documentation.