### PR TITLE
[dev/tooling]: add basic devcontainer setup w/ node, pnpm, go, nix & recommended tools

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential libnss3-tools mkcert pkg-config && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+  "name": "headplane",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "upgradePackages": true,
+      "username": "vscode"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "nodeGypDependencies": true,
+      "version": "22.18"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.25.1"
+    },
+    "ghcr.io/devcontainers/features/nix:1": {
+      "extraNixConfig": "experimental-features = nix-command flakes,accept-flake-config = true"
+    }
+  },
+  "containerEnv": {
+    "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "golang.go",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.vscode-typescript-next"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "go.useLanguageServer": true
+      }
+    }
+  },
+  "forwardPorts": [3000, 5173],
+  "postCreateCommand": "pnpm config set store-dir $HOME/.pnpm-store --global && pnpm install",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,3 +55,20 @@ If you plan to work with the WASM SSH agent, you will need to install
 `mkcert` or an equivalent to create certificates in `./test/caddy/certs`.
 It expects a `localhost.pem` and `localhost-key.pem` file to be present in that
 directory. PNPM has a script to do it with `pnpm mkcert` already already.
+
+### Development Container
+
+This repository includes a Dev Container setup in `./.devcontainer` with:
+
+- Node.js
+- PNPM
+- Go
+- Nix
+- `mkcert` and related local certificate tooling
+
+Open the repository in VS Code (or any Dev Container compatible editor) and
+start the container. On first creation, dependencies are installed automatically
+with `pnpm install`.
+
+The base image is Debian (instead of Alpine) to keep compatibility with common
+official Dev Container features used by this project (Node, Go, and Docker).


### PR DESCRIPTION
This PR adds a devcontainer setup w/ documentation on how to use it.

## Changes

- Add [`.devcontainer/devcontainer.json`](./.devcontainer/devcontainer.json)
- Add [`.devcontainer/Dockerfile`](./.devcontainer/Dockerfile)
- Update [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md) with Dev Container section

## Validation

- [`.devcontainer/devcontainer.json`](./.devcontainer/devcontainer.json) parses successfully and opens in vscode without issues
- all [`build.sh`](./build.sh) variants, recommended tools & lint/typecheck run without issues

Closes #499

---

On a different node - thank you @tale for your open source work! Cheers & greets from Zürich!