### PR TITLE
Fetch OIDC profile pictures server-side when URL requires authentication

### DIFF
--- a/app/routes/auth/oidc-callback.ts
+++ b/app/routes/auth/oidc-callback.ts
@@ -67,18 +67,38 @@ export async function loader({ request, context }: Route.LoaderArgs) {
         ? `${userInfo.given_name} ${userInfo.family_name}`
         : (userInfo.preferred_username ?? "SSO User"));
 
-    const picture =
-      context.config.oidc?.profile_picture_source === "gravatar"
-        ? (() => {
-            if (!userInfo.email) {
-              return undefined;
-            }
+    const picture = await (async () => {
+      if (context.config.oidc?.profile_picture_source === "gravatar") {
+        if (!userInfo.email) {
+          return undefined;
+        }
 
-            const emailHash = userInfo.email.trim().toLowerCase();
-            const hash = createHash("sha256").update(emailHash).digest("hex");
-            return `https://www.gravatar.com/avatar/${hash}?s=200&d=identicon&r=x`;
-          })()
-        : userInfo.picture;
+        const emailHash = userInfo.email.trim().toLowerCase();
+        const hash = createHash("sha256").update(emailHash).digest("hex");
+        return `https://www.gravatar.com/avatar/${hash}?s=200&d=identicon&r=x`;
+      }
+
+      if (!userInfo.picture) {
+        return undefined;
+      }
+
+      try {
+        const response = await fetch(userInfo.picture, {
+          headers: { Authorization: `Bearer ${tokens.access_token}` },
+        });
+
+        if (response.ok) {
+          const contentType = response.headers.get("content-type");
+          if (contentType?.startsWith("image/")) {
+            const buffer = await response.arrayBuffer();
+            const base64 = Buffer.from(buffer).toString("base64");
+            return `data:${contentType};base64,${base64}`;
+          }
+        }
+      } catch {}
+
+      return userInfo.picture;
+    })();
 
     const userId = await context.auth.findOrCreateUser(claims.sub, {
       name,


### PR DESCRIPTION
Some OIDC providers (e.g. Microsoft Entra ID) return a profile picture URL that requires a Bearer token to access. The browser cannot attach auth headers to `<img>` tags, resulting in a 401.

This change fetches the picture server-side during the OIDC callback using the access token already available from the auth code grant. If the response is an image, it's converted to a base64 data URI and stored in the session. If the fetch fails or the content isn't an image, it falls back to the original URL.

Fixes [#326](https://github.com/tale/headplane/issues/326)