### PR TITLE
fix: correct patch path and permissions in nix/ssh-wasm.nix

### DIFF
--- a/nix/ssh-wasm.nix
+++ b/nix/ssh-wasm.nix
@@ -26,6 +26,7 @@ in
       # Patch Tailscale's derphttp to include DERPPort in WebSocket URLs.
       # Without this, DERP servers on non-443 ports fail in WASM builds.
       if [ -f patches/tailscale-derp-port.patch ]; then
+        chmod -R +w vendor/tailscale.com/derp/derphttp
         patch -d vendor/tailscale.com -p1 < patches/tailscale-derp-port.patch
       fi
 

--- a/nix/ssh-wasm.nix
+++ b/nix/ssh-wasm.nix
@@ -26,7 +26,7 @@ in
       # Patch Tailscale's derphttp to include DERPPort in WebSocket URLs.
       # Without this, DERP servers on non-443 ports fail in WASM builds.
       if [ -f patches/tailscale-derp-port.patch ]; then
-        patch -d vendor -p1 < patches/tailscale-derp-port.patch
+        patch -d vendor/tailscale.com -p1 < patches/tailscale-derp-port.patch
       fi
 
       go build -mod=vendor -o hp_ssh.wasm ./cmd/hp_ssh


### PR DESCRIPTION
The Nix build of `headplane-ssh-wasm` fails after commit 44dffea introduced `patches/tailscale-derp-port.patch`.
Two issues in `nix/ssh-wasm.nix`:

1. **Wrong patch directory:** `patch -d vendor -p1` should be `patch -d vendor/tailscale.com -p1`.
The target file is at `vendor/tailscale.com/derp/derphttp/derphttp_client.go`.
`build.sh:149` already uses the correct path.
 
2. **Read-only vendor files:** `buildGoModule` copies vendor from the read-only
Nix store. `patch(1)` needs write permission to modify files in-place.
Added `chmod -R +w` before patching — this is the standard pattern used by
nixpkgs packages (coredns, authentik, mcap-cli, etc.) that patch vendored
Go dependencies.

## Build error (before fix)
```
can't find file to patch at input line 10
Perhaps you used the wrong -p or --strip option?
```

## Testing
Verified with `nix build` on NixOS 25.11 (x86_64) — builds successfully with both fixes applied.

## Issue
Fixes #523 