### PR TITLE
Add key expiry disable/enable toggle

### DIFF
--- a/app/routes/machines/components/machine-row.tsx
+++ b/app/routes/machines/components/machine-row.tsx
@@ -28,6 +28,7 @@ interface Props {
   isDisabled?: boolean;
   existingTags?: string[];
   supportsNodeOwnerChange: boolean;
+  supportsDisablingKeyExpiry: boolean;
 }
 
 export default function MachineRow({
@@ -38,6 +39,7 @@ export default function MachineRow({
   isDisabled,
   existingTags,
   supportsNodeOwnerChange,
+  supportsDisablingKeyExpiry,
 }: Props) {
   const uiTags = useMemo(() => uiTagsForNode(node, isAgent), [node, isAgent]);
 
@@ -144,6 +146,7 @@ export default function MachineRow({
           node={node}
           users={users}
           supportsNodeOwnerChange={supportsNodeOwnerChange}
+          supportsDisablingKeyExpiry={supportsDisablingKeyExpiry}
         />
       </td>
     </tr>

--- a/app/routes/machines/components/menu.tsx
+++ b/app/routes/machines/components/menu.tsx
@@ -1,11 +1,12 @@
 import { Cog, Ellipsis, SquareTerminal } from "lucide-react";
 import { useState } from "react";
+import { useSubmit } from "react-router";
 
 import Button from "~/components/button";
 import { Menu, MenuContent, MenuItem, MenuSeparator, MenuTrigger } from "~/components/menu";
 import type { User } from "~/types";
 import cn from "~/utils/cn";
-import { PopulatedNode } from "~/utils/node-info";
+import { isNoExpiry, type PopulatedNode } from "~/utils/node-info";
 
 import Delete from "../dialogs/delete";
 import Expire from "../dialogs/expire";
@@ -35,6 +36,7 @@ export default function MachineMenu({
   existingTags,
   supportsNodeOwnerChange,
 }: MenuProps) {
+  const submit = useSubmit();
   const [modal, setModal] = useState<Modal>(null);
   const supportsTailscaleSSH = node.hostInfo?.sshHostKeys && node.hostInfo?.sshHostKeys.length > 0;
 
@@ -156,15 +158,31 @@ export default function MachineMenu({
         </MenuTrigger>
         <MenuContent>
           <MenuItem onClick={() => setModal("rename")}>Edit machine name</MenuItem>
+          <MenuItem
+            onClick={() =>
+              submit(
+                {
+                  action_id: "toggle_expiry",
+                  node_id: node.id,
+                  disableExpiry: !isNoExpiry(node.expiry),
+                },
+                { method: "post" },
+              )
+            }
+          >
+            {isNoExpiry(node.expiry) ? "Enable" : "Disable"} key expiry
+          </MenuItem>
           <MenuItem onClick={() => setModal("routes")}>Edit route settings</MenuItem>
           <MenuItem onClick={() => setModal("tags")}>Edit ACL tags</MenuItem>
           {supportsNodeOwnerChange && (
             <MenuItem onClick={() => setModal("move")}>Change owner</MenuItem>
           )}
           <MenuSeparator />
-          <MenuItem variant="danger" disabled={node.expired} onClick={() => setModal("expire")}>
-            Expire
-          </MenuItem>
+          {!isNoExpiry(node.expiry) && (
+            <MenuItem variant="danger" disabled={node.expired} onClick={() => setModal("expire")}>
+              Expire
+            </MenuItem>
+          )}
           <MenuItem variant="danger" onClick={() => setModal("remove")}>
             Remove
           </MenuItem>

--- a/app/routes/machines/components/menu.tsx
+++ b/app/routes/machines/components/menu.tsx
@@ -23,6 +23,7 @@ interface MenuProps {
   isDisabled?: boolean;
   existingTags?: string[];
   supportsNodeOwnerChange: boolean;
+  supportsDisablingKeyExpiry: boolean;
 }
 
 type Modal = "rename" | "expire" | "remove" | "routes" | "move" | "tags" | null;
@@ -35,6 +36,7 @@ export default function MachineMenu({
   isDisabled,
   existingTags,
   supportsNodeOwnerChange,
+  supportsDisablingKeyExpiry,
 }: MenuProps) {
   const submit = useSubmit();
   const [modal, setModal] = useState<Modal>(null);
@@ -158,20 +160,22 @@ export default function MachineMenu({
         </MenuTrigger>
         <MenuContent>
           <MenuItem onClick={() => setModal("rename")}>Edit machine name</MenuItem>
-          <MenuItem
-            onClick={() =>
-              submit(
-                {
-                  action_id: "toggle_expiry",
-                  node_id: node.id,
-                  disableExpiry: !isNoExpiry(node.expiry),
-                },
-                { method: "post" },
-              )
-            }
-          >
-            {isNoExpiry(node.expiry) ? "Enable" : "Disable"} key expiry
-          </MenuItem>
+          {supportsDisablingKeyExpiry && (
+            <MenuItem
+              onClick={() =>
+                submit(
+                  {
+                    action_id: "toggle_expiry",
+                    node_id: node.id,
+                    disableExpiry: !isNoExpiry(node.expiry),
+                  },
+                  { method: "post" },
+                )
+              }
+            >
+              {isNoExpiry(node.expiry) ? "Enable" : "Disable"} key expiry
+            </MenuItem>
+          )}
           <MenuItem onClick={() => setModal("routes")}>Edit route settings</MenuItem>
           <MenuItem onClick={() => setModal("tags")}>Edit ACL tags</MenuItem>
           {supportsNodeOwnerChange && (

--- a/app/routes/machines/machine-actions.ts
+++ b/app/routes/machines/machine-actions.ts
@@ -113,6 +113,13 @@ export async function machineAction({ request, context }: Route.ActionArgs) {
       return { message: "Machine expired" };
     }
 
+    case "toggle_expiry": {
+      const disableExpiry = String(formData.get("disableExpiry")) === "true";
+      await api.nodes.toggleExpiry(nodeId, disableExpiry);
+      await headscaleLiveStore.refresh(nodesResource, api);
+      return { message: "Machine expired" };
+    }
+
     case "update_tags": {
       const tags = formData.get("tags")?.toString().split(",") ?? [];
       if (tags.length === 0) {

--- a/app/routes/machines/machine.tsx
+++ b/app/routes/machines/machine.tsx
@@ -66,6 +66,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
   const [enhancedNode] = mapNodes([node], stats);
   const tags = [...node.tags].toSorted();
   const supportsNodeOwnerChange = !headscale.capabilities.nodeOwnerIsImmutable;
+  const supportsDisablingKeyExpiry = headscale.capabilities.keyExpiryCanBeDisabled;
   const agentSync = agents?.lastSync();
   const policy = policyResult.status === "fulfilled" ? policyResult.value.policy : undefined;
 
@@ -82,6 +83,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     node: enhancedNode,
     stats: stats?.[enhancedNode.nodeKey],
     supportsNodeOwnerChange: supportsNodeOwnerChange,
+    supportsDisablingKeyExpiry: supportsDisablingKeyExpiry,
     tags,
     users,
   };
@@ -90,7 +92,17 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
 export const action = machineAction;
 
 export default function Page({
-  loaderData: { node, tags, users, magic, agent, stats, existingTags, supportsNodeOwnerChange },
+  loaderData: {
+    node,
+    tags,
+    users,
+    magic,
+    agent,
+    stats,
+    existingTags,
+    supportsNodeOwnerChange,
+    supportsDisablingKeyExpiry,
+  },
 }: Route.ComponentProps) {
   const [showRouting, setShowRouting] = useState(false);
 
@@ -125,6 +137,7 @@ export default function Page({
           node={node}
           users={users}
           supportsNodeOwnerChange={supportsNodeOwnerChange}
+          supportsDisablingKeyExpiry={supportsDisablingKeyExpiry}
         />
       </div>
       <div className="mb-4 flex gap-1">

--- a/app/routes/machines/overview.tsx
+++ b/app/routes/machines/overview.tsx
@@ -67,6 +67,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
   const policy = policyResult.status === "fulfilled" ? policyResult.value.policy : undefined;
   const populatedNodes = mapNodes(nodes, stats);
   const supportsNodeOwnerChange = !headscale.capabilities.nodeOwnerIsImmutable;
+  const supportsDisablingKeyExpiry = headscale.capabilities.keyExpiryCanBeDisabled;
   const agentSync = agents?.lastSync();
 
   return {
@@ -86,6 +87,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     publicServer: config.headscale.public_url,
     server: config.headscale.url,
     supportsNodeOwnerChange: supportsNodeOwnerChange,
+    supportsDisablingKeyExpiry: supportsDisablingKeyExpiry,
     users,
     writable: writablePermission,
   };
@@ -458,6 +460,7 @@ export default function Page({ loaderData }: Route.ComponentProps) {
                   node={node}
                   users={loaderData.users}
                   supportsNodeOwnerChange={loaderData.supportsNodeOwnerChange}
+                  supportsDisablingKeyExpiry={loaderData.supportsDisablingKeyExpiry}
                 />
               ))
             )}

--- a/app/server/headscale/api/capabilities.ts
+++ b/app/server/headscale/api/capabilities.ts
@@ -44,6 +44,11 @@ export interface Capabilities {
    * the `hskey-authreq-` prefix. Introduced in 0.29.0.
    */
   readonly registerKeyIncludesAuthReqPrefix: boolean;
+
+  /**
+   * Disabling of key expiry was introduced in 0.29.0.
+   */
+  readonly keyExpiryCanBeDisabled: boolean;
 }
 
 export function capabilitiesFor(version: ServerVersion): Capabilities {
@@ -52,5 +57,6 @@ export function capabilitiesFor(version: ServerVersion): Capabilities {
     nodeTagsAreFlat: gte(version, "0.28.0"),
     nodeOwnerIsImmutable: gte(version, "0.28.0"),
     registerKeyIncludesAuthReqPrefix: gte(version, "0.29.0"),
+    keyExpiryCanBeDisabled: gte(version, "0.29.0"),
   };
 }

--- a/app/server/headscale/api/resources/nodes.ts
+++ b/app/server/headscale/api/resources/nodes.ts
@@ -19,6 +19,7 @@ export interface NodeApi {
   expire(id: string): Promise<void>;
   rename(id: string, newName: string): Promise<void>;
   setTags(id: string, tags: string[]): Promise<void>;
+  toggleExpiry(nodeId: string, disableExpiry: boolean): Promise<void>;
   /**
    * Reassign a node to a different user. Only present when
    * `capabilities.nodeOwnerIsImmutable` is false (Headscale < 0.28).
@@ -102,6 +103,13 @@ export function makeNodeApi(
         path: `v1/node/${id}/tags`,
         apiKey,
         body: { tags },
+      });
+    },
+    toggleExpiry: async (nodeId, disableExpiry) => {
+      await transport.request({
+        method: "POST",
+        path: `v1/node/${nodeId}/expire?disableExpiry=${disableExpiry}`,
+        apiKey,
       });
     },
   };

--- a/tests/integration/api/nodes.test.ts
+++ b/tests/integration/api/nodes.test.ts
@@ -111,7 +111,13 @@ describe.sequential.for(HS_VERSIONS)("Headscale %s: Users", (version) => {
     expect(expiredNode.expiry).toBeDefined();
   });
 
-  test("key expiry of nodes can be toggled", async () => {
+  test("key expiry of nodes can be toggled", async (context) => {
+    const bootstrap = await getBootstrapClient(version);
+    // Key expiry was introduced in 0.29.0
+    if (!bootstrap.capabilities.keyExpiryCanBeDisabled) {
+      context.skip();
+    }
+
     const client = await getRuntimeClient(version);
     await client.nodes.toggleExpiry(workingNodeId, true);
 

--- a/tests/integration/api/nodes.test.ts
+++ b/tests/integration/api/nodes.test.ts
@@ -111,6 +111,21 @@ describe.sequential.for(HS_VERSIONS)("Headscale %s: Users", (version) => {
     expect(expiredNode.expiry).toBeDefined();
   });
 
+  test("key expiry of nodes can be toggled", async () => {
+    const client = await getRuntimeClient(version);
+    await client.nodes.toggleExpiry(workingNodeId, true);
+
+    const permanentNode = await client.nodes.get(workingNodeId);
+    expect(permanentNode).toBeDefined();
+    expect(permanentNode.expiry).toBeNull();
+
+    await client.nodes.toggleExpiry(workingNodeId, false);
+
+    const node = await client.nodes.get(workingNodeId);
+    expect(node).toBeDefined();
+    expect(node.expiry).not.toBeNull();
+  });
+
   test("nodes can be deleted", async () => {
     const client = await getRuntimeClient(version);
     await client.nodes.delete(workingNodeId);

--- a/tests/unit/headscale/server-version.test.ts
+++ b/tests/unit/headscale/server-version.test.ts
@@ -98,6 +98,7 @@ describe("capabilitiesFor", () => {
       nodeTagsAreFlat: true,
       nodeOwnerIsImmutable: true,
       registerKeyIncludesAuthReqPrefix: false,
+      keyExpiryCanBeDisabled: false,
     });
   });
 


### PR DESCRIPTION
This PR adds a button to the node menu to disable (and re-enable) node key expiry, as requested by #553. Since headscale does not store the key expiry toggle state separately from the actual expiry date, re-enabling key expiry sadly currently will result in a node that expired at the time of re-enabling the key expiry. This is not the case with official tailscale, which seems to pick up the original key expiry date from before key expiry was disabled. Hence, I'm actually unsure myself if this feature adds much to the UX of headplane :shrug: 