### PR TITLE
fix: constrain dialog panel height and make content scrollable

### DIFF
--- a/app/components/dialog.tsx
+++ b/app/components/dialog.tsx
@@ -58,7 +58,8 @@ function Panel(props: DialogPanelProps) {
   return (
     <AlertDialog.Popup
       className={cn(
-        "w-full max-w-lg rounded-xl p-4",
+        "flex w-full max-w-lg flex-col rounded-xl p-4",
+        "max-h-[90dvh]",
         "outline-hidden",
         "bg-white dark:bg-mist-900",
         "border border-mist-200 dark:border-mist-800",
@@ -67,6 +68,7 @@ function Panel(props: DialogPanelProps) {
     >
       <Form
         method={method ?? "POST"}
+        className="flex min-h-0 flex-1 flex-col"
         onSubmit={(event) => {
           if (onSubmit) {
             onSubmit(event);
@@ -77,8 +79,8 @@ function Panel(props: DialogPanelProps) {
           }
         }}
       >
-        <div className="flex flex-col gap-4">{children}</div>
-        <div className="mt-5 flex justify-end gap-3">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">{children}</div>
+        <div className="mt-5 flex shrink-0 justify-end gap-3">
           {variant === "unactionable" ? (
             <AlertDialog.Close render={<Button>Close</Button>} />
           ) : (


### PR DESCRIPTION
The route approval dialog overflows the viewport when a machine advertises many subnet routes, making it impossible to scroll to routes below the fold or reach the action buttons.

## Changes

- **`app/components/dialog.tsx`**
  - Cap `AlertDialog.Popup` at `max-h-[90dvh]` with `flex flex-col` so the panel never exceeds the viewport
  - Add `flex min-h-0 flex-1 flex-col` to `Form` to propagate the flex height constraint down
  - Make the children container `overflow-y-auto flex-1 min-h-0` — content scrolls, buttons don't
  - Mark the button row `shrink-0` so Close/Confirm are always visible regardless of content length

```tsx
// Before
<AlertDialog.Popup className="w-full max-w-lg rounded-xl p-4 ...">
  <Form ...>
    <div className="flex flex-col gap-4">{children}</div>
    <div className="mt-5 flex justify-end gap-3">
```

```tsx
// After
<AlertDialog.Popup className="flex w-full max-w-lg flex-col max-h-[90dvh] rounded-xl p-4 ...">
  <Form className="flex min-h-0 flex-1 flex-col" ...>
    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">{children}</div>
    <div className="mt-5 flex shrink-0 justify-end gap-3">
```

Applies globally to all dialogs, so any future content-heavy dialog gets the same treatment.

see attached screenshots
before:
<img width="1616" height="1183" alt="Screenshot 2026-05-12 at 10 36 46" src="https://github.com/user-attachments/assets/4812970c-6f8d-4c54-8f18-4c04158094d4" />

after:
<img width="1621" height="1192" alt="Screenshot 2026-05-12 at 10 36 55" src="https://github.com/user-attachments/assets/3560256a-0db7-4385-b4a7-21629a2fab0c" />

