### PR TITLE
fix(wasm): make whole vendored tailscale tree writable before patching

### DIFF
--- a/nix/ssh-wasm.nix
+++ b/nix/ssh-wasm.nix
@@ -26,7 +26,7 @@ in
       # Patch Tailscale's derphttp to include DERPPort in WebSocket URLs.
       # Without this, DERP servers on non-443 ports fail in WASM builds.
       if [ -f patches/tailscale-derp-port.patch ]; then
-        chmod -R +w vendor/tailscale.com/derp/derphttp
+        chmod -R +w vendor/tailscale.com
         patch -d vendor/tailscale.com -p1 < patches/tailscale-derp-port.patch
       fi
 


### PR DESCRIPTION
Since c8b1a30 the `tailscale-derp-port.patch` now also modifies `net/netcheck/netcheck.go`. Since only `vendor/tailscale.com/derp/derphttp` was chmod'd writable, the patch was failing again on the read-only vendored file (a regression, since previously fixed by c4ac28f).

This commit changes the chmod to scope entire vendor-tree, so should future-proof patch from potential future regressions.