### PR TITLE
fix: treat Go pseudo-versions as unknown server versions

### DIFF
--- a/app/server/headscale/api/server-version.ts
+++ b/app/server/headscale/api/server-version.ts
@@ -15,6 +15,13 @@
 
 const SEMVER_RE = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/;
 
+// Go pseudo-version prerelease segment: `<14-digit timestamp>-<12-hex sha>`,
+// e.g. the prerelease part of `v0.0.0-20260703052708-048308511c72`. Untagged
+// Headscale builds (per-commit `main-*` / `development` Docker images) report
+// this instead of `dev`, and it parses as semver 0.0.0 — which would strip
+// every capability from a server that actually runs the newest code.
+const GO_PSEUDO_VERSION_PRERELEASE_RE = /^\d{14}-[0-9a-f]{12}$/;
+
 export interface ServerVersion {
   readonly major: number;
   readonly minor: number;
@@ -47,6 +54,26 @@ export function parseServerVersion(raw: string): ServerVersion {
     };
   }
   const [, maj, min, pat, pre, build] = match;
+  // A Go pseudo-version (v0.0.0-<timestamp>-<sha>) is an untagged dev build,
+  // not an ancient release: treat it like `dev` so capability checks assume
+  // the modern code paths instead of gating everything off.
+  if (
+    Number(maj) === 0 &&
+    Number(min) === 0 &&
+    Number(pat) === 0 &&
+    pre !== undefined &&
+    GO_PSEUDO_VERSION_PRERELEASE_RE.test(pre)
+  ) {
+    return {
+      major: 0,
+      minor: 0,
+      patch: 0,
+      prerelease: pre,
+      build,
+      raw,
+      unknown: true,
+    };
+  }
   return {
     major: Number(maj),
     minor: Number(min),

--- a/tests/unit/headscale/server-version.test.ts
+++ b/tests/unit/headscale/server-version.test.ts
@@ -39,6 +39,21 @@ describe("parseServerVersion", () => {
     expect(v.unknown).toBe(true);
     expect(v.raw).toBe("dev");
   });
+
+  test("flags Go pseudo-versions from untagged builds as unknown", () => {
+    // Headscale's per-commit Docker images (main-*, development) report a
+    // Go pseudo-version instead of `dev`. Parsing it as semver 0.0.0 would
+    // deny every capability to a server running the newest code.
+    const v = parseServerVersion("v0.0.0-20260703052708-048308511c72");
+    expect(v.unknown).toBe(true);
+    expect(v.raw).toBe("v0.0.0-20260703052708-048308511c72");
+  });
+
+  test("does not flag a genuine 0.0.0 prerelease as unknown", () => {
+    const v = parseServerVersion("v0.0.0-beta.1");
+    expect(v.unknown).toBe(false);
+    expect(v.prerelease).toBe("beta.1");
+  });
 });
 
 describe("gte", () => {


### PR DESCRIPTION
## Problem

Headscale's untagged builds — the per-commit `main-*` and `development` Docker images — report a Go pseudo-version from `GET /version`, e.g.:

```
v0.0.0-20260703052708-048308511c72
```

`parseServerVersion` matches this against the semver regex successfully, so it comes back as `0.0.0` with `unknown: false`. Every capability in `capabilitiesFor()` is then denied, and the UI shows **"Agent requires Headscale 0.28 or newer"** against a server that is actually running the newest code on main.

The existing design intent (per the comment on `ServerVersion.unknown`) is that unrecognizable versions like `dev` should be treated as fully capable so modern code paths get exercised. A Go pseudo-version is exactly such a dev build — it just happens to parse.

## Fix

Detect the pseudo-version shape — `0.0.0` with a `<14-digit timestamp>-<12-hex sha>` prerelease — and return `unknown: true` for it, same as `dev`. A genuine `0.0.0` prerelease (e.g. `v0.0.0-beta.1`) still parses normally.

## Testing

- Added a unit test for the pseudo-version case and a guard test that `v0.0.0-beta.1` is *not* flagged unknown
- `pnpm vitest run --project unit tests/unit/headscale/server-version.test.ts` — 14/14 pass
- Hit this in production running `headscale/headscale:main-0483085` behind Headplane 0.7.0; with this change the agent gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)