### PR TITLE
fix: fall back to execCommand when clipboard API is unavailable

### DIFF
--- a/app/components/attribute.tsx
+++ b/app/components/attribute.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy, Info } from "lucide-react";
 
+import { copyToClipboard } from "~/utils/clipboard";
 import cn from "~/utils/cn";
 import toast from "~/utils/toast";
 
@@ -46,12 +47,17 @@ export default function Attribute({ name, value, tooltip, isCopyable }: Attribut
             type="button"
             className="relative flex w-full min-w-0 items-center gap-1.5"
             onClick={async (event) => {
+              const success = await copyToClipboard(value);
+              if (!success) {
+                toast(`Failed to copy ${name} to clipboard`);
+                return;
+              }
+
               const svgs = event.currentTarget.querySelectorAll("svg");
               for (const svg of svgs) {
                 svg.toggleAttribute("data-copied", true);
               }
 
-              await navigator.clipboard.writeText(value);
               toast(`Copied ${name} to clipboard`);
 
               setTimeout(() => {

--- a/app/components/code-block.tsx
+++ b/app/components/code-block.tsx
@@ -1,5 +1,6 @@
 import { Copy } from "lucide-react";
 
+import { copyToClipboard } from "~/utils/clipboard";
 import cn from "~/utils/cn";
 import toast from "~/utils/toast";
 
@@ -20,8 +21,8 @@ export default function CodeBlock({ children, className }: CodeBlockProps) {
         className,
       )}
       onClick={async () => {
-        await navigator.clipboard.writeText(text);
-        toast("Copied to clipboard");
+        const success = await copyToClipboard(text);
+        toast(success ? "Copied to clipboard" : "Failed to copy to clipboard");
       }}
     >
       <code className="block px-3 pt-2 pb-1 text-sm break-all">{text}</code>

--- a/app/routes/machines/components/machine-row.tsx
+++ b/app/routes/machines/components/machine-row.tsx
@@ -11,6 +11,7 @@ import { HeadplaneAgentTag } from "~/components/tags/HeadplaneAgent";
 import { SubnetTag } from "~/components/tags/Subnet";
 import { TailscaleSSHTag } from "~/components/tags/TailscaleSSH";
 import type { User } from "~/types";
+import { copyToClipboard } from "~/utils/clipboard";
 import cn from "~/utils/cn";
 import * as hinfo from "~/utils/host-info";
 import { isNoExpiry, type PopulatedNode } from "~/utils/node-info";
@@ -85,8 +86,12 @@ export default function MachineRow({
                 <MenuItem
                   key={ip}
                   onClick={async () => {
-                    await navigator.clipboard.writeText(ip);
-                    toast("Copied IP address to clipboard");
+                    const success = await copyToClipboard(ip);
+                    toast(
+                      success
+                        ? "Copied IP address to clipboard"
+                        : "Failed to copy IP address to clipboard",
+                    );
                   }}
                 >
                   <div

--- a/app/utils/clipboard.ts
+++ b/app/utils/clipboard.ts
@@ -1,0 +1,34 @@
+/**
+ * Copies text to the clipboard, returning whether the copy succeeded.
+ *
+ * `navigator.clipboard` only exists in secure contexts (HTTPS or
+ * `localhost`), which self-hosted Headplane instances often aren't served
+ * over. When it's unavailable, or the async clipboard write fails, this
+ * falls back to the legacy `document.execCommand("copy")` approach instead
+ * of throwing.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the legacy fallback below.
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.append(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}


### PR DESCRIPTION
## What

Clicking any copy-to-clipboard action (code block, copyable attribute value, or the IP address menu on the Machines page) threw an uncaught `TypeError: Cannot read properties of undefined (reading 'writeText')` in the browser console and silently failed to copy anything.

## Why

`navigator.clipboard` only exists in secure contexts (HTTPS or `localhost`). Headplane is frequently self-hosted and accessed over plain HTTP (LAN, reverse proxy without TLS to the browser, etc.), so `navigator.clipboard` is `undefined` there, and calling `.writeText(...)` on it threw instead of failing gracefully or falling back to a legacy copy method.

## Fix

- Added `copyToClipboard(text)` in `app/utils/clipboard.ts`: tries `navigator.clipboard.writeText` when available, and falls back to the legacy `document.execCommand("copy")` approach (via a temporary off-screen `<textarea>`) when the Clipboard API is unavailable or the write fails. Returns `true`/`false` instead of throwing.
- Updated the three call sites (`code-block.tsx`, `attribute.tsx`, `machine-row.tsx`) to use the new helper and toast a "Failed to copy ..." message on failure instead of crashing.

## Testing

- `pnpm run typecheck` and `pnpm run lint` pass.
- Manually verified copy still works via the fallback path when `navigator.clipboard` is unset.

closes #597