### PR TITLE
feat(acl): Introduction of reachability map

### DIFF
--- a/app/routes/acls/acl-loader.ts
+++ b/app/routes/acls/acl-loader.ts
@@ -1,8 +1,12 @@
 import { data } from "react-router";
 
-import { authContext, requestApiContext } from "~/server/context";
+import { authContext, headscaleLiveStoreContext, requestApiContext } from "~/server/context";
 import { isDataWithApiError } from "~/server/headscale/api/error-client";
+import { nodesResource } from "~/server/headscale/live-store";
 import { Capabilities } from "~/server/web/roles";
+import type { AclNode } from "~/utils/acl/model";
+import { toAclNode } from "~/utils/acl/to-node";
+import { mapNodes } from "~/utils/node-info";
 
 import type { Route } from "./+types/overview";
 
@@ -30,10 +34,24 @@ export async function aclLoader({ request, context }: Route.LoaderArgs) {
     access: auth.can(principal, Capabilities.write_policy),
     writable: false,
     policy: "",
+    // Reduced node shapes for the reachability map. Empty when the user cannot
+    // read machines, or when the fetch fails — the map degrades, the editor
+    // keeps working.
+    nodes: [] as AclNode[],
   };
 
   // Try to load the ACL policy from the API.
   const { api } = await getRequestApi(request);
+
+  if (auth.can(principal, Capabilities.read_machines)) {
+    try {
+      const headscaleLiveStore = context.get(headscaleLiveStoreContext);
+      const nodesSnap = await headscaleLiveStore.get(nodesResource, api);
+      flags.nodes = mapNodes(nodesSnap.data).map(toAclNode);
+    } catch {
+      // Non-fatal: the map shows nothing rather than breaking the ACL page.
+    }
+  }
   try {
     const { policy, updatedAt } = await api.policy.get();
     flags.writable = updatedAt !== null;

--- a/app/routes/acls/components/cm.client.tsx
+++ b/app/routes/acls/components/cm.client.tsx
@@ -1,6 +1,7 @@
 import * as shopify from "@shopify/lang-jsonc";
-import CodeMirror from "@uiw/react-codemirror";
+import CodeMirror, { EditorSelection, EditorView } from "@uiw/react-codemirror";
 import { BookCopy, CircleX } from "lucide-react";
+import { useEffect, useRef } from "react";
 import Merge from "react-codemirror-merge";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -10,9 +11,42 @@ interface EditorProps {
   isDisabled?: boolean;
   value: string;
   onChange: (value: string) => void;
+  /** Character range to reveal and select, e.g. the rule the map jumped from. */
+  highlight?: { start: number; end: number } | undefined;
+  /**
+   * Identifies the jump, not the range. The range is rescanned from the live
+   * buffer on every keystroke, so keying off it would re-impose the selection
+   * while you type.
+   */
+  highlightKey?: string;
 }
 
 export function Editor(props: EditorProps) {
+  const viewRef = useRef<EditorView | null>(null);
+  // Read at apply time rather than captured by the effect, so applying once
+  // still uses the current range.
+  const highlightRef = useRef(props.highlight);
+  highlightRef.current = props.highlight;
+  const appliedRef = useRef<string | undefined>(undefined);
+
+  // Revealing is a ONE-SHOT action per jump. It used to re-run whenever the
+  // computed range changed, which meant every edit re-selected and refocused
+  // mid-keystroke — deleting the highlighted token would fight the controlled
+  // value sync and appear to paste text back in.
+  const applyOnce = (view: EditorView) => {
+    if (appliedRef.current === props.highlightKey) return;
+    appliedRef.current = props.highlightKey;
+    reveal(view, highlightRef.current);
+  };
+
+  // Applied from two places because the order is not guaranteed: switching
+  // tabs remounts the editor, so the view may only exist by the time
+  // onCreateEditor fires — but on a second jump the view is already there and
+  // only this effect runs.
+  useEffect(() => {
+    if (viewRef.current) applyOnce(viewRef.current);
+  }, [props.highlightKey]);
+
   return (
     <div className="text-sm">
       <ErrorBoundary
@@ -29,6 +63,10 @@ export function Editor(props: EditorProps) {
           minHeight="24rem"
           maxHeight="var(--height-editor)"
           onChange={(value) => props.onChange(value)}
+          onCreateEditor={(view) => {
+            viewRef.current = view;
+            applyOnce(view);
+          }}
           readOnly={props.isDisabled}
           theme={headplaneTheme}
           value={props.value}
@@ -36,6 +74,24 @@ export function Editor(props: EditorProps) {
       </ErrorBoundary>
     </div>
   );
+}
+
+/**
+ * Select a range and scroll it into view. Positions come from a scan of the
+ * live editor buffer, but the document can still have moved on, so anything
+ * out of bounds is ignored rather than throwing inside a dispatch.
+ */
+function reveal(view: EditorView, at?: { start: number; end: number }): void {
+  if (!at) return;
+  const { start, end } = at;
+  if (start < 0 || end > view.state.doc.length || end <= start) return;
+
+  const range = EditorSelection.range(start, end);
+  view.dispatch({
+    selection: range,
+    effects: EditorView.scrollIntoView(range, { y: "center" }),
+  });
+  view.focus();
 }
 
 interface DifferProps {

--- a/app/routes/acls/components/map.client.tsx
+++ b/app/routes/acls/components/map.client.tsx
@@ -1,0 +1,3028 @@
+import {
+  Background,
+  BaseEdge,
+  Controls,
+  type Edge,
+  type EdgeProps,
+  getBezierPath,
+  getStraightPath,
+  Handle,
+  type InternalNode,
+  MarkerType,
+  type Node,
+  type NodeProps,
+  Panel,
+  Position,
+  ReactFlow,
+  type ReactFlowInstance,
+  useEdgesState,
+  useInternalNode,
+  useNodesState,
+} from "@xyflow/react";
+
+import "@xyflow/react/dist/style.css";
+import {
+  CircleAlert,
+  Eye,
+  EyeOff,
+  Focus,
+  FunnelX,
+  ListFilter,
+  Search,
+  ToggleLeft,
+  ToggleRight,
+  X,
+} from "lucide-react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useSearchParams } from "react-router";
+
+import Tooltip from "~/components/tooltip";
+import { evaluatePolicy } from "~/utils/acl/evaluate";
+import {
+  type AclEdge,
+  type AclEvaluation,
+  type AclNode,
+  type EdgeRule,
+  INTERNET,
+  isSubnetNodeId,
+  type PortRange,
+} from "~/utils/acl/model";
+import { portTokens, summarisePorts } from "~/utils/acl/ports";
+import cn from "~/utils/cn";
+
+interface ReachabilityMapProps {
+  nodes: AclNode[];
+  /** The SAVED policy — the map shows what is actually being enforced. */
+  policy: string;
+  /** The editor buffer has diverged from it, so the map is not your draft. */
+  unsaved?: boolean;
+}
+
+// Accent colours chosen to read on both the light and dark themes, rather than
+// tied to the mist palette (which flips between them).
+const ACCENT = {
+  selected: "#6366f1", // indigo — the node you clicked
+  out: "#10b981", // emerald — it can reach these
+  in: "#f59e0b", // amber — these can reach it
+  both: "#d946ef", // magenta — traffic flows both ways (kept clear of indigo)
+  idle: "#94a3b8", // slate — no selection
+} as const;
+
+type Role = keyof typeof ACCENT;
+type Direction = "all" | "in" | "out";
+
+/**
+ * How far a filtered-out thing recedes. Shared by nodes and the lines running
+ * to them: a full-strength line into a greyed node reads as a live flow to a
+ * machine that is not there.
+ */
+const DIMMED_OPACITY = 0.2;
+
+/** Stable identity, so passing "no filter" is not a new object every render. */
+const EMPTY_SET = new Set<string>();
+
+const COLUMN_GAP = 340;
+const ROW_GAP = 72;
+
+/**
+ * Fallback only, used for the frame before the real height is measured and for
+ * the empty states. A constant cannot be correct in every state: the unsaved
+ * banner and the warnings block both change how much room is left, so
+ * `useAvailableHeight` measures instead. See there for why.
+ */
+const MAP_HEIGHT = "calc(var(--height-editor) - 5.5rem)";
+
+const MIN_MAP_HEIGHT = 320;
+
+/**
+ * Asymmetric on purpose: the canvas has overlays in two corners, and fitting
+ * the graph edge-to-edge parks nodes underneath them. Extra room at the bottom
+ * clears the legend (bottom-right) and the zoom controls (bottom-left), with a
+ * little more on the left for the controls' width.
+ */
+const FIT_PADDING = (() => {
+  return {
+    // Clears the collapsed filter button at top-left. The expanded picker is
+    // deliberately NOT reserved for: it is a popover you are interacting with,
+    // and reflowing the whole graph every time it opens would be worse than
+    // it briefly covering a node.
+    top: "64px",
+    right: "24px",
+    bottom: "96px",
+    left: "56px",
+  } as const;
+})();
+
+/**
+ * A two-way pair is drawn as two real edges rather than one line wearing two
+ * decorative dash streams: each leg then has its own arrowhead, its own
+ * animation direction, and — the point — its own hit area, so the two can be
+ * clicked apart. Each steps this far off the centre line, in flow units.
+ */
+const LANE_SPREAD = 5;
+
+/**
+ * React Flow gives every edge an invisible band for clicking, 20 units wide by
+ * default. Two lanes 10 units apart would have almost entirely overlapping
+ * bands, so a click would land on whichever edge rendered last rather than the
+ * one aimed at. Narrowing it to match the separation keeps them distinct.
+ */
+const LANE_INTERACTION = 10;
+
+/** Layout positions are node centres; see the `nodeOrigin` prop for why. */
+const NODE_ORIGIN: [number, number] = [0.5, 0.5];
+
+/**
+ * How far the dash streams stop short of each end, so a dash ends where the
+ * arrow begins. React Flow's ArrowClosed reaches back 5 viewBox units of a
+ * `-10 -10 20 20` box at markerWidth 12.5, scaled again by the stroke width.
+ */
+function arrowLength(strokeWidth: number): number {
+  return 5 * (12.5 / 20) * strokeWidth;
+}
+
+/**
+ * Size the map so the page fills the viewport exactly and does not scroll.
+ *
+ * Measured, not computed from the parts: enumerating every contributor (tabs,
+ * toolbar, warnings, `<main>`'s 96px margin, the fixed footer) mis-sizes the
+ * canvas silently when one is missed. Shrinking the map shrinks the document
+ * one-for-one, so adjusting by the measured overflow converges in one pass,
+ * and slack reads as a negative overflow so the map grows into it.
+ */
+function useAvailableHeight(ref: RefObject<HTMLElement | null>, watch: unknown[]): number | null {
+  const [height, setHeight] = useState<number | null>(null);
+
+  // Layout effect, not effect: this runs before paint, so the canvas is
+  // already its final size when React Flow initialises. Measuring afterwards
+  // meant a resize on every arrival, and React Flow keeps its viewport
+  // transform across resizes. Safe here — this module is client-only.
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const measure = () => {
+      const current = element.getBoundingClientRect().height;
+      if (current === 0) return; // not laid out yet; a later pass will catch it
+
+      // The page's real content bottom, in document space. `scrollHeight` is
+      // no use here: it never reports less than the viewport height, so a page
+      // SHORTER than the viewport looks like a perfect fit and the map could
+      // only ever shrink — which is how it ended up small with a large gap
+      // beneath it. Deriving the bottom from rects reports slack as a negative
+      // overflow, so the map grows into it.
+      const container = element.closest("main") ?? document.body;
+      const documentTop = document.documentElement.getBoundingClientRect().top;
+      const marginBottom = Number.parseFloat(getComputedStyle(container).marginBottom) || 0;
+      const contentBottom = container.getBoundingClientRect().bottom - documentTop + marginBottom;
+
+      const overflow = contentBottom - window.innerHeight;
+      if (Math.abs(overflow) <= 1) return; // already exact, ignore rounding
+
+      const next = Math.max(MIN_MAP_HEIGHT, Math.round(current - overflow));
+      setHeight((previous) => (previous === next ? previous : next));
+    };
+
+    // A couple of settling passes: the first runs before paint, the rest after
+    // scrollbars, fonts and scroll clamping have resolved. Bounded, so it can
+    // never spin.
+    let frame = 0;
+    const settle = (remaining: number) => {
+      measure();
+      if (remaining > 0) frame = requestAnimationFrame(() => settle(remaining - 1));
+    };
+
+    const onResize = () => settle(1);
+    settle(2);
+    window.addEventListener("resize", onResize);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", onResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, watch);
+
+  return height;
+}
+
+/** URL search params backing the map's selection. Kept in sync with overview.tsx. */
+const PARAM = {
+  node: "node",
+  flow: "flow",
+  edge: "edge",
+  tab: "tab",
+  rule: "rule",
+  token: "token",
+  only: "only",
+  hide: "hide",
+  suspend: "qoff",
+  animate: "anim",
+} as const;
+
+/** The view settings the filter panel owns, all backed by search params. */
+type FilterKey = "only" | "hide" | "suspend" | "animate";
+
+// Handle ids. The layout runs left-to-right, so nodes anchor left and right;
+// React Flow's default node only has top/bottom, which sends every edge diving
+// out of the bottom and looping back across the graph.
+const HANDLE = { target: "t", source: "s" } as const;
+
+export function ReachabilityMap({ nodes, policy, unsaved = false }: ReachabilityMapProps) {
+  // This has only ever been exercised against one real policy. Anything the
+  // evaluator chokes on degrades to an empty map with the reason shown, rather
+  // than throwing through render and taking the whole ACL page — including the
+  // editor holding unsaved changes — down with it.
+  const evaluation = useMemo((): AclEvaluation => {
+    try {
+      return evaluatePolicy(policy, nodes);
+    } catch (error) {
+      return {
+        edges: [],
+        rules: [],
+        subnets: [],
+        reachOut: new Map(),
+        reachIn: new Map(),
+        expansions: new Map(),
+        warnings: [
+          {
+            message: `Could not evaluate this policy: ${
+              error instanceof Error ? error.message : String(error)
+            }. The editor is unaffected — please report the policy shape that caused this.`,
+          },
+        ],
+      };
+    }
+  }, [policy, nodes]);
+  // Overview-only, and deliberately not in the URL: hovering is transient and
+  // must not create history entries.
+  const [hovered, setHovered] = useState<string | null>(null);
+  // Which flow the cursor is over, so you can see what a click would select.
+  const [hoveredEdge, setHoveredEdge] = useState<string | null>(null);
+  // Lifted out of FilterPanel so that clicking the canvas can close it.
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const flowRef = useRef<ReactFlowInstance<Node, Edge> | null>(null);
+  const layoutRef = useRef<HTMLDivElement | null>(null);
+  const colorMode = useColorMode();
+  // Re-measured when the chrome above the map changes size: the unsaved banner
+  // and the warnings block are the two things that move it.
+  const mapHeight = useAvailableHeight(layoutRef, [unsaved, evaluation.warnings.length]);
+
+  // Selection lives in the URL rather than component state, so the browser's
+  // own history gives back/forward for free. See `shouldRevalidate` in
+  // overview.tsx — these params must not trigger a loader refetch.
+  const knownIds = useMemo(() => {
+    const ids = new Set<string>(nodes.map((n) => n.id));
+    ids.add(INTERNET);
+    for (const subnet of evaluation.subnets) ids.add(subnet.id);
+    return ids;
+  }, [nodes, evaluation]);
+
+  // A stale or hand-edited id (a machine since deleted, say) falls back to the
+  // overview instead of focusing on a node that is not there.
+  const nodeParam = searchParams.get(PARAM.node);
+  const selectedNode = nodeParam !== null && knownIds.has(nodeParam) ? nodeParam : null;
+  // The filter is sticky across history moves. An entry created before the
+  // filter was chosen carries no `flow` param, so reading the URL alone would
+  // silently reset to "all" on Back. The URL still wins when it has a value,
+  // which keeps a shared link honest.
+  const [lastFlow, setLastFlow] = useState<Direction>("all");
+  const flowParam = searchParams.get(PARAM.flow);
+  const direction: Direction = flowParam === "in" || flowParam === "out" ? flowParam : lastFlow;
+
+  const focusOn = (node: string | null, flow: Direction, alsoClearFilter = false) => {
+    // Every change of focus is its own history entry, so Back and Forward walk
+    // the trail of nodes you inspected. Switching the direction filter is a
+    // change of view rather than of subject, so it replaces instead — it would
+    // otherwise double the entries for no navigational gain.
+    const nodeChanged = (searchParams.get(PARAM.node) ?? null) !== node;
+
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (node === null) next.delete(PARAM.node);
+        else next.set(PARAM.node, node);
+        if (flow === "all") next.delete(PARAM.flow);
+        else next.set(PARAM.flow, flow);
+        if (alsoClearFilter) {
+          next.delete(PARAM.only);
+          next.delete(PARAM.suspend);
+          next.delete(PARAM.hide);
+        }
+        // Changing the node or the filter invalidates any selected flow: it
+        // may not even be drawn in the new view.
+        next.delete(PARAM.edge);
+        return next;
+      },
+      // preventScrollReset stops the page jumping to the top on every click.
+      { preventScrollReset: true, replace: !nodeChanged },
+    );
+  };
+
+  // Opening a rule in the editor PUSHES, unlike the map's own state changes:
+  // it is a different view, and Back should land back on the map exactly as it
+  // was. The map params ride along untouched so that entry restores them.
+  const jumpToRule = (ruleIndex: number, token?: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set(PARAM.tab, "edit");
+        next.set(PARAM.rule, String(ruleIndex));
+        if (token) next.set(PARAM.token, token);
+        else next.delete(PARAM.token);
+        return next;
+      },
+      { preventScrollReset: true },
+    );
+  };
+
+  const labels = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const node of nodes) map.set(node.id, node.name);
+    map.set(INTERNET, "Internet");
+    for (const subnet of evaluation.subnets) map.set(subnet.id, subnet.cidr);
+    return map;
+  }, [nodes, evaluation]);
+
+  const edgesById = useMemo(() => {
+    const map = new Map<string, AclEdge>();
+    for (const edge of evaluation.edges) map.set(edgeId(edge), edge);
+    return map;
+  }, [evaluation]);
+
+  // --- Node filter --------------------------------------------------------
+  // An explicit set of chosen nodes, not a live text match: the search box in
+  // the picker narrows the list only, so a node stays chosen after the term is
+  // cleared. Empty means no filter, which is also what "select all" means.
+  const onlyParam = searchParams.get(PARAM.only) ?? "";
+  const suspended = searchParams.get(PARAM.suspend) === "1";
+  const hideOthers = searchParams.get(PARAM.hide) === "1";
+  // Off by default: motion draws the eye, so the idle graph stays still and
+  // only what you point at or pick moves. Ticking this runs every line at once,
+  // for reading the tailnet's traffic as a whole rather than one flow at a time.
+  const animateAll = searchParams.get(PARAM.animate) === "1";
+
+  const chosen = useMemo(
+    () => new Set(onlyParam.split(",").filter((id) => id.length > 0)),
+    [onlyParam],
+  );
+
+  const filterActive = !suspended && chosen.size > 0;
+
+  /**
+   * What reads as "in scope", or null when nothing is filtered. The map
+   * changes mode at two, and so does the rules panel beside it:
+   *
+   * - **one chosen** — that machine and everyone it talks to ("its world").
+   * - **two or more** — exactly the chosen; their other peers become
+   *   background, since the question is now what passes between them.
+   */
+  const litSet = useMemo(() => {
+    if (!filterActive) return null;
+    if (chosen.size > 1) return new Set(chosen);
+    const ids = new Set(chosen);
+    for (const id of chosen) {
+      for (const peer of evaluation.reachOut.get(id) ?? []) ids.add(peer);
+      for (const peer of evaluation.reachIn.get(id) ?? []) ids.add(peer);
+    }
+    return ids;
+  }, [filterActive, chosen, evaluation]);
+
+  // The node under inspection is always exempt: greying the subject of the view
+  // because it was left out of a later selection would be disorienting.
+  const isMatch = (id: string) =>
+    litSet === null || litSet.has(id) || (selectedNode !== null && id === selectedNode);
+
+  /** Everything the picker can offer, machines first, then the pseudo-nodes. */
+  const roster = useMemo(() => {
+    const machines: FilterItem[] = nodes.map((node) => ({
+      id: node.id,
+      label: node.name,
+      detail: [node.user, ...node.tags].filter(Boolean).join(" · "),
+      haystack: [node.name, node.user ?? "", ...node.tags, ...node.ips].join(" ").toLowerCase(),
+    }));
+
+    const extras: FilterItem[] = [];
+    if (evaluation.edges.some((edge) => edge.dst === INTERNET)) {
+      extras.push({ id: INTERNET, label: "Internet", detail: "", haystack: "internet" });
+    }
+    for (const subnet of evaluation.subnets) {
+      extras.push({
+        id: subnet.id,
+        label: subnet.cidr,
+        detail: "subnet",
+        haystack: (subnet.cidr + " subnet").toLowerCase(),
+      });
+    }
+
+    return { machines, extras };
+  }, [nodes, evaluation]);
+
+  const setFilter = (updates: Partial<Record<FilterKey, string | null>>) => {
+    // Changing what the map shows drops any selected flow, as changing the
+    // node or direction already does: a selection narrows every view to its
+    // two ends, greying out the change just asked for. "Animate all flows" is
+    // excluded — it draws the same map, differently.
+    const changesWhatIsShown = Object.keys(updates).some((key) => key !== "animate");
+
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        for (const [key, value] of Object.entries(updates)) {
+          const param = PARAM[key as FilterKey];
+          if (value === null || value === "") next.delete(param);
+          else next.set(param, value);
+        }
+        if (changesWhatIsShown) next.delete(PARAM.edge);
+        return next;
+      },
+      // A view setting, not a step worth retracing.
+      { preventScrollReset: true, replace: true },
+    );
+  };
+
+  const toggleChosen = (id: string) => {
+    const next = new Set(chosen);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setFilter({ only: [...next].join(",") });
+  };
+
+  const toggleMany = (ids: string[], selected: boolean) => {
+    const next = new Set(chosen);
+    for (const id of ids) {
+      if (selected) next.add(id);
+      else next.delete(id);
+    }
+    setFilter({ only: [...next].join(",") });
+  };
+
+  // One navigation, not two: consecutive setSearchParams calls both build from
+  // the same `prev` and the second would drop the first. Memoised because it
+  // rides in node data, which the graph memo depends on.
+  const inspect = useCallback(
+    (id: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const ids = new Set(chosen);
+          ids.add(id);
+          next.set(PARAM.only, [...ids].join(","));
+          next.set(PARAM.node, id);
+          // The flow you had open belongs to the view you are leaving.
+          next.delete(PARAM.edge);
+          return next;
+        },
+        // A change of subject, so it joins the trail Back walks.
+        { preventScrollReset: true },
+      );
+    },
+    [chosen, setSearchParams],
+  );
+
+  // --- Selected flow ------------------------------------------------------
+  // Read after the filter, since whether a selection still stands depends on
+  // it. Kept in the URL because opening a rule unmounts this panel, so local
+  // state would not survive coming Back; an id that no longer resolves falls
+  // back to no selection.
+  const edgeParam = searchParams.get(PARAM.edge);
+  const resolvedEdge = edgeParam === null ? null : (edgesById.get(edgeParam) ?? null);
+
+  /**
+   * A flow with an end the filter has hidden or greyed is not a selection: it
+   * would narrow every view to its two ends on behalf of a line that is not
+   * even drawn, dimming the whole map. Reachable by selecting a flow while
+   * suspended and then resuming.
+   */
+  const selectionHidden =
+    resolvedEdge !== null && (!isMatch(resolvedEdge.src) || !isMatch(resolvedEdge.dst));
+  const selectedEdge = selectionHidden ? null : resolvedEdge;
+
+  // Each direction is its own line now, so a click selects that leg alone and
+  // the panel describes exactly it. The return leg is one lane over, and one
+  // click away.
+  const selectedFlows = useMemo(() => {
+    if (selectedEdge === null) return [];
+    // The overview draws each leg as its own line, so a click there means
+    // exactly the leg clicked. The focused view collapses a two-way pair into
+    // ONE line, so clicking it has to mean both — otherwise half the rules go
+    // missing. Under a direction filter only one leg is drawn either way.
+    if (selectedNode === null || direction !== "all") return [selectedEdge];
+    const reverse = edgesById.get(`${selectedEdge.dst}->${selectedEdge.src}`);
+    return reverse ? [selectedEdge, reverse] : [selectedEdge];
+  }, [selectedEdge, edgesById, selectedNode, direction]);
+
+  const selectedId = selectedEdge === null ? null : edgeId(selectedEdge);
+
+  const selectEdge = (id: string | null) => {
+    // Picking a flow is a selection too, so it joins the trail: Back closes
+    // the flow and leaves you on the node you were inspecting.
+    const changed = (searchParams.get(PARAM.edge) ?? null) !== id;
+
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (id === null) next.delete(PARAM.edge);
+        else next.set(PARAM.edge, id);
+        return next;
+      },
+      { preventScrollReset: true, replace: !changed },
+    );
+  };
+
+  // Drop it from the URL as well, so suspending the filter later does not
+  // resurrect a selection the user has long since moved on from. REPLACE, not
+  // push: this is the app correcting its own state rather than the user
+  // navigating, and Back must not step into the broken view again.
+  useEffect(() => {
+    if (!selectionHidden) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete(PARAM.edge);
+        return next;
+      },
+      { preventScrollReset: true, replace: true },
+    );
+  }, [selectionHidden, setSearchParams]);
+
+  const graph = useMemo(() => {
+    // Hovering a greyed line previews what clicking it would bring in: its two
+    // machines lift out of the grey. Without that the click is a leap — the
+    // line runs off to somewhere you cannot see.
+    const hoveredFlow = hoveredEdge === null ? null : (edgesById.get(hoveredEdge) ?? null);
+    const previewIds =
+      hoveredFlow !== null && (!isMatch(hoveredFlow.src) || !isMatch(hoveredFlow.dst))
+        ? new Set([hoveredFlow.src, hoveredFlow.dst])
+        : null;
+
+    const usesInternet = evaluation.edges.some((e) => e.dst === INTERNET);
+    const allIds = [
+      ...nodes.map((n) => n.id),
+      ...(usesInternet ? [INTERNET] : []),
+      ...evaluation.subnets.map((s) => s.id),
+    ];
+
+    // --- Overview: everything on a ring ---------------------------------
+    if (selectedNode === null) {
+      const radius = Math.max(220, allIds.length * 30);
+      // With nothing selected, the hovered node is the reference point that
+      // the direction filter measures from.
+      const hoverOut = hovered === null ? [] : (evaluation.reachOut.get(hovered) ?? []);
+      const hoverIn = hovered === null ? [] : (evaluation.reachIn.get(hovered) ?? []);
+      const neighbours =
+        hovered === null
+          ? null
+          : new Set(
+              direction === "out"
+                ? hoverOut
+                : direction === "in"
+                  ? hoverIn
+                  : [...hoverOut, ...hoverIn],
+            );
+
+      // A clicked flow stays emphasised here too, not just under the cursor,
+      // and its two ends read as the conversation the panel is describing.
+      const selectedEnds =
+        selectedEdge === null ? null : new Set([selectedEdge.src, selectedEdge.dst]);
+
+      // Under a direction filter, only nodes that actually participate in that
+      // direction stay connected. Internet is never a source, so it keeps no
+      // lines at all in the outbound view. BOTH endpoints must participate,
+      // otherwise a line would reappear through its other end.
+      const participating = new Set(
+        direction === "all"
+          ? allIds
+          : allIds.filter((id) =>
+              direction === "out"
+                ? (evaluation.reachOut.get(id)?.length ?? 0) > 0
+                : (evaluation.reachIn.get(id)?.length ?? 0) > 0,
+            ),
+      );
+
+      // Every leg is its own edge, offset onto its own lane, so a two-way pair
+      // carries two arrowheads and can be clicked apart rather than stacking
+      // invisibly. Hiding drops nodes from the ring so the rest re-pack.
+      const ringIds = hideOthers ? allIds.filter(isMatch) : allIds;
+      const onRing = new Set(ringIds);
+      // What hiding would remove from THIS view, counted before it is applied
+      // so the control still reports a number while active and can be undone.
+      // Zero below two chosen, where hiding would strand a lone box.
+      const hideableCount = chosen.size < 2 ? 0 : allIds.length - allIds.filter(isMatch).length;
+
+      /**
+       * Which legs belong in this view. With machines chosen, direction is
+       * measured FROM them; without one there is no reference point, so it
+       * falls back to participation — which is what keeps Internet, never a
+       * source, out of the outbound view. At least one end must be chosen
+       * either way: a line between two peers is somebody else's conversation.
+       */
+      const inThisView = (edge: AclEdge) => {
+        if (!filterActive) {
+          return (
+            direction === "all" || (participating.has(edge.src) && participating.has(edge.dst))
+          );
+        }
+        if (direction === "out") return chosen.has(edge.src);
+        if (direction === "in") return chosen.has(edge.dst);
+        return chosen.has(edge.src) || chosen.has(edge.dst);
+      };
+
+      const drawn = evaluation.edges.filter(
+        (edge) => onRing.has(edge.src) && onRing.has(edge.dst) && inThisView(edge),
+      );
+
+      /**
+       * A node belongs here when it has a line drawn — greyed has to mean "no
+       * traffic in this view". Participation is the wrong test: an agent that
+       * only initiates has no inbound flows of its own yet its leg into a
+       * chosen machine is the point, and an outbound-only peer participates
+       * inbound elsewhere while nothing is drawn for it here.
+       */
+      const connected = new Set<string>();
+      for (const edge of drawn) {
+        connected.add(edge.src);
+        connected.add(edge.dst);
+      }
+
+      const inView = (id: string) =>
+        isMatch(id) &&
+        (connected.has(id) ||
+          // A machine picked by hand stays lit even when this direction leaves
+          // it without lines: it is the subject of the view, not a bystander.
+          chosen.has(id) ||
+          // Nothing filtered and no direction to measure against, so there is
+          // nothing to be outside of — an isolated machine still belongs.
+          (!filterActive && direction === "all"));
+
+      const legsPerPair = new Map<string, number>();
+      for (const edge of drawn) {
+        const key = pairKey(edge.src, edge.dst);
+        legsPerPair.set(key, (legsPerPair.get(key) ?? 0) + 1);
+      }
+
+      /**
+       * Hover lifts what it touches out of the grey — `!inView` is part of the
+       * dim, so without this the pointer does nothing at all on a node outside
+       * the filter. Far ends come from the lines actually DRAWN: lifting a
+       * machine with no visible connection would claim a relationship the map
+       * is not showing.
+       */
+      // The machine a line's direction is measured against, so it can wear the
+      // legend's colours. One pick, or — with no filter at all — whatever is
+      // under the cursor, so hovering reads the same way as picking. `null`
+      // past one pick, where a line can be outbound for one and inbound for
+      // another and no single colour is honest.
+      const colourRef = filterActive ? (chosen.size === 1 ? [...chosen][0] : null) : hovered;
+      const drawnKeys = new Set(drawn.map((edge) => `${edge.src}->${edge.dst}`));
+
+      const hoverEnds = new Set<string>();
+      if (hovered !== null) {
+        hoverEnds.add(hovered);
+        for (const edge of drawn) {
+          if (edge.src === hovered) hoverEnds.add(edge.dst);
+          else if (edge.dst === hovered) hoverEnds.add(edge.src);
+        }
+      }
+
+      return {
+        hiddenCount: 0,
+        // The ring is laid out from its membership and nothing else, so this is
+        // the whole of what can move a node here. Notably absent: the direction
+        // filter, which restyles lines without touching a single position.
+        layoutId: `ring:${ringIds.join(",")}`,
+        drawnIds: new Set(drawn.map(edgeId)),
+        hideableCount,
+        rfEdges: drawn.map((edge): Edge => {
+          // Dimmed rather than hidden: still drawn, but unreachable until the
+          // filter is cleared or suspended.
+          const muted = !isMatch(edge.src) || !isMatch(edge.dst);
+          const selected = selectedId === edgeId(edge);
+          const underCursor = hoveredEdge === edgeId(edge);
+          // A leg is lit when the hovered node is at the end the filter cares
+          // about — its source under Outbound, its target under Inbound.
+          const underHoveredNode =
+            hovered !== null &&
+            (direction === "out"
+              ? edge.src === hovered
+              : direction === "in"
+                ? edge.dst === hovered
+                : edge.src === hovered || edge.dst === hovered);
+
+          // A picked machine's traffic stays lit, not just while the cursor is
+          // on it. Which lines those are falls out of `muted` for free, and so
+          // follows the same one-versus-many rule as the panel.
+          const lit = underHoveredNode || (filterActive && !muted);
+
+          // Only lines that touch the reference machine have a direction
+          // relative to it; with nothing filtered the whole ring is drawn, so
+          // most of it does not.
+          // `lit` as well, or under a direction filter a line the view is not
+          // emphasising would still take a colour and read as a faint stray.
+          const touchesRef =
+            lit && colourRef !== null && (edge.src === colourRef || edge.dst === colourRef);
+          const roleColour =
+            !touchesRef || muted || selected
+              ? undefined
+              : drawnKeys.has(`${edge.dst}->${edge.src}`)
+                ? ACCENT.both
+                : edge.src === colourRef
+                  ? ACCENT.out
+                  : ACCENT.in;
+
+          return overviewEdge(edge, {
+            alwaysAnimate: animateAll,
+            // Always: each line is one directed leg, so a line without a
+            // head would be ambiguous. Showing them only on emphasis made
+            // sense when a line was a collapsed undirected pair.
+            arrowEnd: true,
+            colour: roleColour,
+            // Greyed lines answer the cursor too: hovering a greyed node has
+            // to show which lines it would bring in, or the highlight stops
+            // exactly where the interesting part starts.
+            hovered: underCursor,
+            idle: hovered === null,
+            lit,
+            muted,
+            lane: (legsPerPair.get(pairKey(edge.src, edge.dst)) ?? 1) > 1 ? LANE_SPREAD : 0,
+            otherHovered: hoveredEdge !== null && !underCursor,
+            selected,
+            someSelected: selectedId !== null,
+          });
+        }),
+        rfNodes: ringIds.map((id, i) => {
+          // -90° so the first node sits at the top of the circle.
+          const angle = (i / ringIds.length) * 2 * Math.PI - Math.PI / 2;
+          const related = hovered === null || id === hovered || (neighbours?.has(id) ?? false);
+          const onSelectedFlow = selectedEnds?.has(id) ?? false;
+          const preview = (previewIds?.has(id) ?? false) || hoverEnds.has(id);
+          return buildNode(
+            id,
+            labels,
+            // A chosen machine keeps the accent for as long as it is chosen.
+            // Its peers stay neutral: they are in scope, not picked.
+            chosen.has(id) || id === hovered || onSelectedFlow || preview ? "selected" : "idle",
+            { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius },
+            {
+              // A selected flow narrows the view to its two ends, the same way
+              // it does in the focused view. A previewed end always wins.
+              dim:
+                !preview && (!related || !inView(id) || (selectedEnds !== null && !onSelectedFlow)),
+              onInspect: inspect,
+              selectable: !suspended,
+            },
+          );
+        }),
+      };
+    }
+
+    // --- Focus: only the selection and its direct peers, in lanes -------
+    const reachOut = new Set(evaluation.reachOut.get(selectedNode) ?? []);
+    const reachIn = new Set(evaluation.reachIn.get(selectedNode) ?? []);
+
+    // In a filtered view each lane owns its bidirectional peers outright; in
+    // the combined view they sit on the right so an all-to-all policy does not
+    // pile every node into a single column.
+    const inLane = (ids: string[]) => (hideOthers ? ids.filter(isMatch) : ids);
+    const rawRight = direction === "in" ? [] : [...reachOut];
+    const rawLeft =
+      direction === "out"
+        ? []
+        : direction === "in"
+          ? [...reachIn]
+          : [...reachIn].filter((id) => !reachOut.has(id));
+    const rightLane = inLane(rawRight);
+    const leftLane = inLane(rawLeft);
+
+    // Counted from the unfiltered lanes, so it is what hiding WOULD remove.
+    // Zero below two chosen machines, where the lanes are all lit by
+    // definition — inspecting puts its subject in the filter, and at one
+    // machine everyone it talks to is lit alongside it.
+    const hideableCount =
+      chosen.size < 2 ? 0 : [...rawRight, ...rawLeft].filter((id) => !isMatch(id)).length;
+
+    // Under a filter the view is one-way, so a peer takes that direction's
+    // colour even if it also talks back — matching the single arrow drawn.
+    const roleOf = (id: string): Role => {
+      if (direction === "out") return "out";
+      if (direction === "in") return "in";
+      return reachOut.has(id) && reachIn.has(id) ? "both" : reachOut.has(id) ? "out" : "in";
+    };
+
+    // Picking a flow narrows the view to that one conversation, the same way
+    // hovering does on the overview: its two ends stay lit and everything else
+    // recedes.
+    const litEnds = selectedEdge === null ? null : new Set([selectedEdge.src, selectedEdge.dst]);
+    const dimmed = (id: string): boolean => litEnds !== null && !litEnds.has(id);
+
+    const laneNodes = (ids: string[], x: number): Node[] =>
+      ids.map((id, i) => {
+        const preview = previewIds?.has(id) ?? false;
+        return buildNode(
+          id,
+          labels,
+          roleOf(id),
+          {
+            x,
+            // Centre each lane vertically on the selected node.
+            y: (i - (ids.length - 1) / 2) * ROW_GAP,
+          },
+          {
+            dim: !preview && (dimmed(id) || !isMatch(id)),
+            onInspect: inspect,
+            selectable: !suspended,
+          },
+        );
+      });
+
+    const visible = new Set([selectedNode, ...rightLane, ...leftLane]);
+    const focusEdges = evaluation.edges.filter((e) => {
+      if (e.src === selectedNode) return visible.has(e.dst) && direction !== "in";
+      if (e.dst === selectedNode) return visible.has(e.src) && direction !== "out";
+      return false;
+    });
+
+    // Fold the legs of each conversation together. The focused layout is fixed
+    // columns with source-on-right, target-on-left anchors, so a return leg
+    // drawn as its own edge would leave the peer's right face and wrap all the
+    // way back. One line with a head at each end avoids that; the overview,
+    // which picks nearest border points, uses real per-leg lanes instead.
+    const focusPairs = new Map<string, { edge: AclEdge; outbound: boolean; inbound: boolean }>();
+    for (const edge of focusEdges) {
+      const key = pairKey(edge.src, edge.dst);
+      const outbound = edge.src === selectedNode;
+      const existing = focusPairs.get(key);
+      if (!existing) {
+        focusPairs.set(key, { edge, outbound, inbound: !outbound });
+        continue;
+      }
+      // Prefer the outbound leg as the one drawn, so the line runs into a
+      // right-lane peer rather than back out of it.
+      if (outbound) {
+        existing.edge = edge;
+        existing.outbound = true;
+      } else {
+        existing.inbound = true;
+      }
+    }
+
+    return {
+      hiddenCount: allIds.length - visible.size,
+      // Here the direction filter DOES rearrange things — it empties a lane —
+      // so the lane contents carry it rather than the filter being named.
+      layoutId: `focus:${selectedNode}|${leftLane.join(",")}|${rightLane.join(",")}`,
+      // Every leg this view accounts for, not just the one line drawn per
+      // conversation: a two-way pair collapses onto its outbound leg, but the
+      // return leg is still represented by that line and selecting it is valid.
+      drawnIds: new Set(focusEdges.map(edgeId)),
+      hideableCount,
+      rfNodes: [
+        buildNode(
+          selectedNode,
+          labels,
+          "selected",
+          { x: 0, y: 0 },
+          {
+            dim: dimmed(selectedNode),
+            interactive: false,
+          },
+        ),
+        ...laneNodes(leftLane, -COLUMN_GAP),
+        ...laneNodes(rightLane, COLUMN_GAP),
+      ],
+      rfEdges: [...focusPairs.values()].map(({ edge, outbound, inbound }) => {
+        const both = outbound && inbound;
+        const isSelected = selectedId === edgeId(edge);
+        const isHovered = hoveredEdge === edgeId(edge);
+        // The peer at the far end is filtered out, so this line recedes to
+        // match it. Only reachable without "hide all others": that drops the
+        // node from the lane and takes its line with it.
+        const isMuted = !isMatch(edge.src) || !isMatch(edge.dst);
+
+        return buildEdge(edge, {
+          muted: isMuted,
+          colour: isSelected
+            ? ACCENT.selected
+            : both
+              ? ACCENT.both
+              : outbound
+                ? ACCENT.out
+                : ACCENT.in,
+          // Same switch as the overview: the panel is on screen in this view
+          // too, so a tick that did nothing here would read as broken.
+          animated: animateAll || isSelected || isHovered,
+          // Unselected flows fade well back once one is picked, so the chosen
+          // conversation reads on its own. Hovering lifts a flow back out of
+          // that fade — including out of a selection's shadow — and pushes the
+          // rest down, so the line under the cursor is unambiguous.
+          opacity: isSelected
+            ? 1
+            : isHovered
+              ? 0.95
+              : litEnds !== null
+                ? 0.08
+                : hoveredEdge !== null
+                  ? 0.12
+                  : 0.75,
+          strokeWidth: isSelected ? 3 : isHovered ? 2.5 : 1.5,
+          arrowEnd: true,
+          arrowStart: both,
+          dual: both,
+        });
+      }),
+    };
+  }, [
+    nodes,
+    evaluation,
+    labels,
+    selectedNode,
+    selectedEdge,
+    direction,
+    hovered,
+    hoveredEdge,
+    // Without these the map read the filter but never recomputed when it
+    // changed: the panel and the URL updated, and nothing moved. `chosen` is
+    // reachable through `litSet` today, but only while the filter is active —
+    // listing it directly keeps that from mattering.
+    litSet,
+    filterActive,
+    // Reachable through `filterActive` for every state that can actually be
+    // toggled, but listed anyway: the last time this memo read something the
+    // deps only implied, the panel and the URL updated and the map did not.
+    suspended,
+    chosen,
+    hideOthers,
+    animateAll,
+    edgesById,
+    inspect,
+  ]);
+
+  const { hiddenCount, layoutId, drawnIds, hideableCount } = graph;
+
+  /**
+   * Adds a node to the filter, or takes it out if already in. Membership only
+   * — never what merely looks lit, since at one chosen machine its peers are
+   * lit too and treating a click on one as "remove" inverts the gesture.
+   */
+  const clickNode = (id: string) => {
+    // Clicking what you are already inspecting does nothing; the background
+    // click and Escape are how you leave.
+    if (id === selectedNode) return;
+    // Suspending freezes the selection. The map ignores the filter entirely in
+    // that state, so a click rewrote the URL while nothing on screen moved —
+    // no greying to gain or lose, no lines to change. The picker's checkboxes
+    // stay live because ticking one is its own feedback; a node click has none.
+    if (suspended) return;
+    toggleChosen(id);
+  };
+
+  // The other half of the same rule: a selection can survive into a view that
+  // does not draw it at all, with both ends still passing the filter, so
+  // `isMatch` cannot see it. Post-render, because only the memo knows what it
+  // drew — testing against its own output during would be circular.
+  useEffect(() => {
+    if (selectedId === null || drawnIds.has(selectedId)) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete(PARAM.edge);
+        return next;
+      },
+      { preventScrollReset: true, replace: true },
+    );
+  }, [selectedId, drawnIds, setSearchParams]);
+  const [rfNodes, setRfNodes, onNodesChange] = useNodesState<Node>([]);
+  const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState<Edge>([]);
+
+  // React Flow writes measured sizes back through onNodesChange, and the
+  // floating edges depend on them — handing it a wholesale-new array (as every
+  // hover does) discards them and the edges collapse to node centres. Reusing
+  // the previous object per id keeps the measurement while style and position
+  // update. The key comes from the arrangement the graph produced, not from
+  // the inputs that feed it, or a direction change counts as a re-layout.
+  const previousLayout = useRef(layoutId);
+
+  useEffect(() => {
+    // Only re-position when the layout itself changed (ring ↔ lanes, or a
+    // different focus). Otherwise keep where each node currently sits, so a
+    // hover — or a node the user dragged to untangle things — does not snap
+    // everything back to the generated position.
+    const sameLayout = previousLayout.current === layoutId;
+    previousLayout.current = layoutId;
+
+    setRfNodes((previous) => {
+      const byId = new Map(previous.map((node) => [node.id, node]));
+      return graph.rfNodes.map((node) => {
+        const existing = byId.get(node.id);
+        if (!existing) return node;
+        return {
+          ...existing,
+          ...node,
+          measured: existing.measured,
+          position: sameLayout ? existing.position : node.position,
+        };
+      });
+    });
+    setRfEdges(graph.rfEdges);
+  }, [graph, layoutId, setRfNodes, setRfEdges]);
+
+  // Re-frame when the arrangement changes — not when the settings feeding it
+  // do, or switching inbound to outbound re-centres a ring that never moved
+  // and throws away the user's pan and zoom. `mapHeight` belongs here too:
+  // React Flow keeps its viewport transform across a resize, so the canvas
+  // being measured after mount would otherwise leave the graph framed for the
+  // pre-measurement height.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => flowRef.current?.fitView({ padding: FIT_PADDING }));
+    return () => cancelAnimationFrame(frame);
+  }, [layoutId, mapHeight]);
+
+  /**
+   * Back out one level at a time: an open flow first, then the focused node.
+   * Shared by Escape and by clicking empty space so the two cannot drift —
+   * closing a flow should never cost you the node you were inspecting.
+   */
+  const stepBack = () => {
+    setHovered(null);
+    setHoveredEdge(null);
+    // Dismiss the picker first and stop there. Clicking away from an open
+    // panel is a "close this" gesture, and it should not also cost you the
+    // selection you were looking at — a second click does that.
+    if (filterOpen) {
+      setFilterOpen(false);
+      return;
+    }
+    if (selectedEdge !== null) {
+      selectEdge(null);
+      return;
+    }
+    if (selectedNode !== null) {
+      // Inspecting is one gesture that sets two things — the focus and the
+      // filter membership — so undoing it has to unwind both, or leaving the
+      // focused view takes a second Escape to finish what one action started.
+      // Only when that machine is all the filter holds: picks made before you
+      // inspected are yours, and predate this gesture.
+      const inspectPutItThere = chosen.size === 1 && chosen.has(selectedNode);
+      focusOn(null, direction, inspectPutItThere);
+      return;
+    }
+    // Last level: the filter itself. Leaving the overview with machines still
+    // picked and no way to drop them but the toolbar made the background click
+    // feel broken, since every other level answers it.
+    if (chosen.size > 0) setFilter({ only: null, suspend: null, hide: null });
+  };
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") stepBack();
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  });
+
+  if (nodes.length === 0) {
+    return (
+      <Empty>
+        No machines to map. The map needs machine data — check that you have permission to view
+        machines and that Headscale is reachable.
+      </Empty>
+    );
+  }
+
+  if (policy.trim().length === 0) {
+    return <Empty>The policy is empty, so nothing is reachable yet.</Empty>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/*
+        Said plainly, because a map that silently showed neither the saved
+        policy nor the draft would be worse than either.
+      */}
+      {unsaved ? (
+        <p className="rounded-md border border-yellow-500/40 bg-yellow-500/5 px-3 py-2 text-xs">
+          You have unsaved changes. This map shows the <strong>saved</strong> policy — what
+          Headscale is enforcing now. Save to see your edits reflected here.
+        </p>
+      ) : undefined}
+
+      <div className="flex items-center gap-1">
+        {(["all", "in", "out"] as const).map((value) => {
+          // "in" and "out" are ACCENT keys, so an active direction wears the
+          // same colour the legend gives its flows. "All flows" has no legend
+          // entry of its own — it is the absence of a direction, not a third
+          // one — so it keeps the neutral active styling.
+          const accent = value === "all" ? undefined : ACCENT[value];
+          const active = direction === value;
+
+          return (
+            <button
+              className={cn(
+                "rounded-md border px-2.5 py-1 text-xs transition-colors",
+                active
+                  ? cn(
+                      "font-medium",
+                      accent
+                        ? undefined
+                        : "border-mist-400 bg-mist-100 dark:border-mist-600 dark:bg-mist-800",
+                    )
+                  : "border-transparent text-mist-500 hover:bg-mist-100 dark:hover:bg-mist-900",
+              )}
+              key={value}
+              onClick={() => {
+                setLastFlow(value);
+                focusOn(selectedNode, value);
+              }}
+              style={
+                active && accent
+                  ? { borderColor: accent, color: accent, background: `${accent}1a` }
+                  : undefined
+              }
+              type="button"
+            >
+              {value === "all" ? "All flows" : value === "in" ? "Inbound" : "Outbound"}
+            </button>
+          );
+        })}
+        <span className="ml-2 text-xs text-mist-500">
+          {selectedNode === null
+            ? direction === "all"
+              ? "Hover a node to highlight its flows, or click to focus on it"
+              : `Hover a node to highlight its ${direction === "in" ? "inbound" : "outbound"} flows, or click to focus on it`
+            : `Hiding ${hiddenCount} unrelated node${hiddenCount === 1 ? "" : "s"} — click the background to show all`}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-3 lg:flex-row" ref={layoutRef}>
+        <div
+          className="flex-1 overflow-hidden rounded-md border border-mist-200 dark:border-mist-800"
+          style={{ height: mapHeight ?? MAP_HEIGHT }}
+        >
+          <ReactFlow
+            colorMode={colorMode}
+            edges={rfEdges}
+            edgeTypes={edgeTypes}
+            fitView
+            // The initial fit must reserve the same corners as the refits.
+            fitViewOptions={{ padding: FIT_PADDING }}
+            nodes={rfNodes}
+            nodesConnectable={false}
+            // Positions address node CENTRES, not top-left corners. Otherwise
+            // two boxes of different widths sit on the same layout point with
+            // their centres offset, and the line joining those centres tilts —
+            // most visible with two nodes on the ring, where a line that ought
+            // to be dead straight leans by half the width difference.
+            nodeOrigin={NODE_ORIGIN}
+            nodeTypes={nodeTypes}
+            onEdgesChange={onEdgesChange}
+            onInit={(instance) => {
+              flowRef.current = instance;
+            }}
+            onNodesChange={onNodesChange}
+            // Greyed nodes and lines are live now: grey means "outside the
+            // filter", and clicking is how you bring something into it, so
+            // refusing the hover would hide the only affordance saying so.
+            onNodeMouseEnter={(_, node) => {
+              if (selectedNode === null) setHovered(node.id);
+            }}
+            onNodeMouseLeave={() => {
+              if (selectedNode === null) setHovered(null);
+            }}
+            onEdgeClick={(_, edge) => {
+              const flow = edgesById.get(edge.id);
+              if (!flow) {
+                selectEdge(null);
+                return;
+              }
+              // A greyed line's rules would describe a flow that is out of
+              // scope, so the click brings its two machines in instead. Same
+              // gesture, and the hover preview says which two.
+              if (!isMatch(flow.src) || !isMatch(flow.dst)) {
+                toggleMany([flow.src, flow.dst], true);
+                return;
+              }
+              selectEdge(edge.id);
+            }}
+            onEdgeMouseEnter={(_, edge) => setHoveredEdge(edge.id)}
+            onEdgeMouseLeave={() => setHoveredEdge(null)}
+            onNodeClick={(_, node) => {
+              setHovered(null);
+              clickNode(node.id);
+            }}
+            // Steps back one level rather than jumping straight to the
+            // overview. stepBack also clears the hover: if a re-render swallows
+            // the mouseleave the highlight sticks, and clicking away then looks
+            // like it did nothing.
+            onPaneClick={stepBack}
+          >
+            <Background />
+            <Controls showInteractive={false} />
+            {/*
+              Transparent to the pointer, with each control opting back in. The
+              row is as tall as the open picker and as wide as picker plus
+              icons, so its empty corner sat over the canvas swallowing clicks —
+              a dead rectangle you could neither click through nor pan from.
+              React Flow's own panel CSS sets no pointer-events, so the box is
+              hit-testable whether or not anything is painted there.
+            */}
+            <Panel className="pointer-events-none" position="top-left">
+              <div className="flex items-start gap-1.5">
+                <FilterPanel
+                  animateAll={animateAll}
+                  chosen={chosen}
+                  extras={roster.extras}
+                  machines={roster.machines}
+                  onChange={setFilter}
+                  onOpenChange={setFilterOpen}
+                  onToggle={toggleChosen}
+                  onToggleMany={toggleMany}
+                  open={filterOpen}
+                  suspended={suspended}
+                />
+                {/*
+                  Both act on the filter as a whole, so they sit beside the
+                  picker rather than inside it — reachable without opening a
+                  panel that covers the map you are deciding about.
+                */}
+                <IconButton
+                  active={filterActive}
+                  disabled={chosen.size === 0}
+                  label={
+                    chosen.size === 0
+                      ? "Nothing is filtered yet"
+                      : suspended
+                        ? "Resume the filter"
+                        : "Suspend the filter, keeping the selection"
+                  }
+                  onClick={() => setFilter({ suspend: suspended ? null : "1" })}
+                >
+                  {suspended ? (
+                    <ToggleLeft className="size-3.5" />
+                  ) : (
+                    <ToggleRight className="size-3.5" />
+                  )}
+                </IconButton>
+                {/*
+                  An open eye means you are seeing everything, so pressing it
+                  closes things down; a closed one means machines are being
+                  held back. Only useful past two picks — with one, the lit set
+                  is that machine and everyone it talks to, and hiding would
+                  strand a single box with no lines.
+                */}
+                <IconButton
+                  active={!hideOthers && hideableCount > 0}
+                  disabled={hideableCount === 0 && !hideOthers}
+                  label={
+                    chosen.size < 2
+                      ? "Select two or more machines to hide the others"
+                      : suspended
+                        ? "Resume the filter to hide the others"
+                        : hideOthers
+                          ? "Show every machine again"
+                          : `Hide the ${hideableCount} machine${hideableCount === 1 ? "" : "s"} outside the filter`
+                  }
+                  onClick={() => setFilter({ hide: hideOthers ? null : "1" })}
+                >
+                  {hideOthers ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+                </IconButton>
+                <IconButton
+                  disabled={chosen.size === 0}
+                  label={
+                    chosen.size === 0 ? "Nothing is filtered yet" : "Clear the filter and show all"
+                  }
+                  onClick={() => setFilter({ only: null, suspend: null, hide: null })}
+                >
+                  <FunnelX className="size-3.5" />
+                </IconButton>
+              </div>
+            </Panel>
+            {/*
+              Inside the canvas rather than under it. The map is sized from the
+              viewport (calc(100vh - 20rem)), so a legend placed below it grows
+              out of reach as the window grows — zooming out never brings it
+              back. Bottom-right keeps it clear of the Controls.
+            */}
+            <Panel position="bottom-right">
+              {/*
+                A grid, not wrapped flex: five items of unequal width wrapped
+                into a right-aligned box left the short row padded away from
+                the left edge. Three auto columns give two rows that line up
+                and a box that is exactly as wide as its contents.
+                The bottom margin clears React Flow's own attribution, which
+                sits in this same corner and was otherwise tucked under it.
+              */}
+              <div
+                className={cn(
+                  "mb-2.5 grid grid-cols-[auto_auto_auto] items-center gap-x-3 gap-y-1",
+                  "rounded-md border border-mist-200 bg-mist-50/85 px-2 py-1.5 text-xs",
+                  "dark:border-mist-800 dark:bg-mist-950/85",
+                )}
+              >
+                <Legend colour={ACCENT.selected}>Selected</Legend>
+                <Legend colour={ACCENT.out}>Can reach</Legend>
+                <Legend colour={ACCENT.in}>Reached by</Legend>
+                <Legend colour={ACCENT.both}>Both ways</Legend>
+                <span className="col-span-2 whitespace-nowrap text-mist-500">
+                  Dashed = Internet or subnet
+                </span>
+              </div>
+            </Panel>
+          </ReactFlow>
+        </div>
+
+        <aside
+          className="shrink-0 overflow-y-auto rounded-md border border-mist-200 p-3 lg:w-80 dark:border-mist-800"
+          style={{ maxHeight: mapHeight ?? MAP_HEIGHT }}
+        >
+          <Summary
+            // Suspending has to reach the panel too, or the canvas un-greys
+            // the machines outside the filter while the column beside it goes
+            // on describing only the chosen ones. An empty set here is what
+            // "no filter" means everywhere else.
+            chosen={filterActive ? chosen : EMPTY_SET}
+            direction={direction}
+            isVisible={isMatch}
+            jumpDisabled={unsaved}
+            onJump={jumpToRule}
+            flows={selectedFlows}
+            evaluation={evaluation}
+            labels={labels}
+            nodes={nodes}
+            onClearEdge={() => selectEdge(null)}
+            selected={selectedNode}
+          />
+        </aside>
+      </div>
+
+      {evaluation.warnings.length > 0 ? (
+        <div className="rounded-md border border-yellow-500/40 bg-yellow-500/5 p-3 text-sm">
+          <div className="mb-1 flex items-center gap-2 font-medium">
+            <CircleAlert className="size-4" />
+            <span>
+              {evaluation.warnings.length} policy warning
+              {evaluation.warnings.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          <ul className="space-y-0.5 text-mist-600 dark:text-mist-400">
+            {evaluation.warnings.map((warning) => (
+              <li
+                className="flex items-start gap-1.5"
+                key={`${warning.ruleIndex ?? "-"}:${warning.message}`}
+              >
+                <span className="flex-1">{warning.message}</span>
+                {/*
+                  Only rule-scoped warnings can be located. A parse failure has
+                  no rule to jump to, so it gets no affordance rather than one
+                  that goes nowhere.
+                */}
+                {warning.ruleIndex !== undefined ? (
+                  <JumpToRule
+                    disabled={unsaved}
+                    onJump={jumpToRule}
+                    ruleIndex={warning.ruleIndex}
+                    token={warning.token}
+                  />
+                ) : undefined}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : undefined}
+    </div>
+  );
+}
+
+// --- Custom node -----------------------------------------------------------
+
+/**
+ * A node with handles on its left and right edges instead of top and bottom.
+ * Forward traffic enters left-upper and leaves right-upper; return traffic
+ * leaves left-lower and enters right-lower. Handles are invisible: they exist
+ * only as anchor points, since the map is not interactively connectable.
+ */
+function FlowNode({ id, data }: NodeProps) {
+  const role = (data.role as Role) ?? "idle";
+  const anchor = { background: "transparent", border: "none", width: 1, height: 1 };
+  const onInspect = data.onInspect as ((id: string) => void) | undefined;
+
+  return (
+    // The wrapper carries no size of its own, so the measured box — which the
+    // floating edges anchor to — is still the label box below.
+    <div
+      className="group relative"
+      // Said on hover rather than on click: the pointer is already there, and
+      // explaining a dead click only once it has been made is late.
+      title={data.selectable === false ? "Toggle the filter back on to select machines" : undefined}
+      style={{
+        // The node being inspected is not clickable, and neither is anything
+        // while the filter is suspended, so neither offers a pointer.
+        // Otherwise every node does, greyed or not: grey means "outside the
+        // filter", and clicking is how you bring it in.
+        cursor: data.interactive === false || data.selectable === false ? "default" : "pointer",
+        pointerEvents: data.interactive === false ? ("none" as const) : undefined,
+      }}
+    >
+      <div
+        style={{
+          background: "var(--cm-bg)",
+          color: "var(--cm-fg)",
+          border: `2px ${data.pseudo ? "dashed" : "solid"} ${ACCENT[role]}`,
+          borderRadius: 8,
+          fontSize: 12,
+          padding: "6px 10px",
+          opacity: data.dim ? DIMMED_OPACITY : 1,
+          transition: "opacity 120ms ease",
+        }}
+      >
+        <Handle id={HANDLE.target} position={Position.Left} style={anchor} type="target" />
+        <Handle id={HANDLE.source} position={Position.Right} style={anchor} type="source" />
+        {String(data.label ?? "")}
+      </div>
+      {/*
+        Outside the box that carries the dim, or it would fade to 20% along
+        with a greyed node — which is exactly when you most need to reach it.
+        Absolutely positioned so it never contributes to the measured size.
+      */}
+      {onInspect ? (
+        <button
+          className={cn(
+            "-top-2.5 -right-2.5 absolute hidden rounded border p-1 opacity-0 transition-opacity",
+            "border-mist-300 bg-mist-50 text-mist-600 shadow-sm hover:text-mist-900",
+            "dark:border-mist-700 dark:bg-mist-900 dark:text-mist-300 dark:hover:text-mist-100",
+            "group-hover:flex group-hover:opacity-100",
+          )}
+          onClick={(event) => {
+            // Or the node's own click would fire too and toggle the filter
+            // instead of — as well as — inspecting.
+            event.stopPropagation();
+            onInspect(id);
+          }}
+          title="Inspect this machine"
+          type="button"
+        >
+          <Focus className="size-3" />
+        </button>
+      ) : undefined}
+    </div>
+  );
+}
+
+const nodeTypes = { flow: FlowNode };
+
+/**
+ * Where the line joining two node centres crosses the border of `node`. Gives
+ * each overview edge the shortest possible run between two boxes, instead of
+ * anchoring it to a fixed handle and sweeping around.
+ */
+function nodeCentre(node: InternalNode<Node>) {
+  return {
+    x: node.internals.positionAbsolute.x + (node.measured?.width ?? 0) / 2,
+    y: node.internals.positionAbsolute.y + (node.measured?.height ?? 0) / 2,
+  };
+}
+
+/**
+ * Where the line towards `other` leaves this node's box, with the lane offset
+ * applied FIRST — post-shifting a point already on the boundary slides it
+ * along and often back inside, burying the arrowhead. Walks from the offset
+ * point out to the first edge crossed (slab method), so the result is on the
+ * boundary whatever the lane.
+ */
+function borderPoint(
+  node: InternalNode<Node>,
+  other: InternalNode<Node>,
+  offset: { x: number; y: number } = { x: 0, y: 0 },
+) {
+  const halfW = (node.measured?.width ?? 0) / 2;
+  const halfH = (node.measured?.height ?? 0) / 2;
+  const centre = nodeCentre(node);
+  const target = nodeCentre(other);
+
+  // Before measurement both boxes are 0×0; fall back to the centre.
+  if (halfW === 0 || halfH === 0) return { x: centre.x + offset.x, y: centre.y + offset.y };
+
+  const dx = target.x - centre.x;
+  const dy = target.y - centre.y;
+  const length = Math.hypot(dx, dy);
+  if (length === 0) return { x: centre.x + offset.x, y: centre.y + offset.y };
+
+  const ux = dx / length;
+  const uy = dy / length;
+  const toVerticalEdge =
+    ux === 0 ? Number.POSITIVE_INFINITY : (Math.sign(ux) * halfW - offset.x) / ux;
+  const toHorizontalEdge =
+    uy === 0 ? Number.POSITIVE_INFINITY : (Math.sign(uy) * halfH - offset.y) / uy;
+  const t = Math.max(0, Math.min(toVerticalEdge, toHorizontalEdge));
+
+  return { x: centre.x + offset.x + ux * t, y: centre.y + offset.y + uy * t };
+}
+
+function FloatingEdge({ id, source, target, style, markerEnd, data }: EdgeProps) {
+  const sourceNode = useInternalNode(source);
+  const targetNode = useInternalNode(target);
+  if (!sourceNode || !targetNode) return null;
+
+  // Each leg of a two-way pair steps off the centre line along the normal.
+  // Both legs carry the same lane value: each computes the normal from its own
+  // direction, and those are opposites, so they land on opposite sides.
+  const lane = typeof data?.lane === "number" ? data.lane : 0;
+  const normal = perpendicular(nodeCentre(sourceNode), nodeCentre(targetNode));
+  const offset = { x: normal.x * lane, y: normal.y * lane };
+
+  const from = borderPoint(sourceNode, targetNode, offset);
+  const to = borderPoint(targetNode, sourceNode, offset);
+  const [path] = getStraightPath({
+    sourceX: from.x,
+    sourceY: from.y,
+    targetX: to.x,
+    targetY: to.y,
+  });
+
+  return (
+    <BaseEdge
+      id={id}
+      // Narrower than the default so two lanes keep distinct hit areas.
+      interactionWidth={lane === 0 ? undefined : LANE_INTERACTION}
+      markerEnd={markerEnd}
+      path={path}
+      style={style}
+    />
+  );
+}
+
+/** getStraightPath takes flattened coordinates; these come as points. */
+/** Unit vector at right angles to the line from `from` to `to`. */
+function perpendicular(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): { x: number; y: number } {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const length = Math.hypot(dx, dy) || 1;
+  return { x: -dy / length, y: dx / length };
+}
+
+/**
+ * Two dash streams running opposite ways, one either side of the line, each
+ * styled like a one-way animated edge. Focused view only: its fixed
+ * source-right/target-left anchors would send a real return leg out of the
+ * peer's far face and back around, so a two-way pair is one line with two
+ * heads. The overview has free geometry and uses real per-leg lanes.
+ */
+function DashStreams({
+  path,
+  colour,
+  width,
+  opacity,
+  normal,
+}: {
+  path: string;
+  colour: string;
+  width: number;
+  opacity: number;
+  normal: { x: number; y: number };
+}) {
+  const stroke = Math.min(width, 2);
+  const spread = stroke / 2 + 0.5;
+  const dx = normal.x * spread;
+  const dy = normal.y * spread;
+  const stream = {
+    fill: "none",
+    stroke: colour,
+    strokeWidth: stroke,
+    strokeDasharray: 5,
+    opacity,
+    // The base path keeps the arrowheads and the click target; these are decor.
+    pointerEvents: "none" as const,
+    animation: "dashdraw 0.5s linear infinite",
+  };
+
+  return (
+    <>
+      <path d={path} style={{ ...stream, transform: `translate(${dx}px, ${dy}px)` }} />
+      <path
+        d={path}
+        style={{
+          ...stream,
+          animationDirection: "reverse",
+          transform: `translate(${-dx}px, ${-dy}px)`,
+        }}
+      />
+    </>
+  );
+}
+
+/**
+ * While the streams run the line itself is drawn with a transparent stroke
+ * rather than a faded one — a one-way animated edge has no solid line under
+ * its dashes. Transparent rather than hidden, so the arrowheads and the wide
+ * interaction path survive.
+ */
+function streamingBaseStyle(style: EdgeProps["style"], active: boolean) {
+  return active ? { ...style, stroke: "transparent" } : style;
+}
+
+/** A two-way conversation in the focused view: one line, a head at each end. */
+function DualFlowEdge({
+  id,
+  sourceX,
+  sourceY,
+  sourcePosition,
+  targetX,
+  targetY,
+  targetPosition,
+  markerEnd,
+  markerStart,
+  style,
+  data,
+  // A custom edge type has to hand this down itself; BaseEdge does not see it
+  // otherwise.
+  interactionWidth,
+}: EdgeProps) {
+  const [path] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const active = data?.active === true;
+  const width = typeof style?.strokeWidth === "number" ? style.strokeWidth : 2;
+  const back = arrowLength(width);
+
+  // Stop the streams exactly where the arrowheads begin: they loop, so without
+  // this a dash slides out from under the head as the previous one arrives.
+  const towards = Math.sign(targetX - sourceX) || 1;
+  const inset = Math.abs(targetX - sourceX) > back * 3 ? back * towards : 0;
+  const [streamPath] = getBezierPath({
+    sourceX: sourceX + inset,
+    sourceY,
+    sourcePosition,
+    targetX: targetX - inset,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        interactionWidth={interactionWidth}
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        path={path}
+        style={streamingBaseStyle(style, active)}
+      />
+      {active ? (
+        <DashStreams
+          colour={String(style?.stroke ?? ACCENT.both)}
+          normal={perpendicular({ x: sourceX, y: sourceY }, { x: targetX, y: targetY })}
+          opacity={typeof style?.opacity === "number" ? style.opacity : 1}
+          path={streamPath}
+          width={width}
+        />
+      ) : undefined}
+    </>
+  );
+}
+
+const edgeTypes = { floating: FloatingEdge, dual: DualFlowEdge };
+
+// --- Right-hand summary ----------------------------------------------------
+
+interface SummaryProps {
+  direction: Direction;
+  /** The filter, which decides both what this describes and how. */
+  chosen: Set<string>;
+  /** Whether a peer survives the node filter, so the lists match the canvas. */
+  isVisible: (id: string) => boolean;
+  /** Jumping is unavailable while the buffer and the saved policy disagree. */
+  jumpDisabled: boolean;
+  onJump: (ruleIndex: number, token?: string) => void;
+  /** Every leg of the selected conversation — one entry, or two if two-way. */
+  flows: AclEdge[];
+  evaluation: AclEvaluation;
+  labels: Map<string, string>;
+  nodes: AclNode[];
+  selected: string | null;
+  onClearEdge: () => void;
+}
+
+/**
+ * Follows the filter and changes mode at two, as the greying does. One
+ * machine: everything it talks to — a single machine has no "between", so the
+ * panel would empty at the moment you picked something. Two or more: only what
+ * passes between them.
+ */
+function Summary({
+  chosen,
+  direction,
+  isVisible,
+  jumpDisabled,
+  onJump,
+  flows,
+  evaluation,
+  labels,
+  nodes,
+  selected,
+  onClearEdge,
+}: SummaryProps) {
+  if (flows.length > 0) {
+    return (
+      <EdgeSummary
+        evaluation={evaluation}
+        selected={selected}
+        jumpDisabled={jumpDisabled}
+        flows={flows}
+        labels={labels}
+        onClose={onClearEdge}
+        onJump={onJump}
+      />
+    );
+  }
+
+  if (chosen.size > 1) {
+    return (
+      <BetweenSummary
+        chosen={chosen}
+        direction={direction}
+        evaluation={evaluation}
+        jumpDisabled={jumpDisabled}
+        labels={labels}
+        onJump={onJump}
+        selected={selected}
+      />
+    );
+  }
+
+  // With exactly one machine chosen it is the subject, whether it got there by
+  // a click or by being inspected. `selected` is the fallback for a hand-made
+  // URL that focuses a node without filtering it.
+  const subject = chosen.size === 1 ? [...chosen][0] : selected;
+
+  if (!subject) {
+    return (
+      <p className="text-sm text-mist-500">
+        Select a node to see which rules apply to it, or an edge to see what permits that flow.
+      </p>
+    );
+  }
+
+  return (
+    <NodeSummary
+      direction={direction}
+      evaluation={evaluation}
+      isVisible={isVisible}
+      jumpDisabled={jumpDisabled}
+      labels={labels}
+      nodes={nodes}
+      onJump={onJump}
+      selected={subject}
+    />
+  );
+}
+
+interface NodeSummaryProps {
+  direction: Direction;
+  evaluation: AclEvaluation;
+  isVisible: (id: string) => boolean;
+  jumpDisabled: boolean;
+  labels: Map<string, string>;
+  nodes: AclNode[];
+  onJump: (ruleIndex: number, token?: string) => void;
+  selected: string;
+}
+
+function NodeSummary({
+  direction,
+  evaluation,
+  isVisible,
+  jumpDisabled,
+  labels,
+  nodes,
+  onJump,
+  selected,
+}: NodeSummaryProps) {
+  const node = nodes.find((n) => n.id === selected);
+  // The panel lists exactly what the map is drawing, so the direction filter
+  // applies here too — otherwise "Inbound" shows one thing on the canvas and
+  // another in the rules beside it.
+  const allOutbound = direction === "in" ? [] : groupByRule(evaluation.edges, selected, "out");
+  const allInbound = direction === "out" ? [] : groupByRule(evaluation.edges, selected, "in");
+
+  const surviving = (groups: RuleGrouping[]) =>
+    groups.filter((group) => group.peers.some(isVisible));
+  const outbound = surviving(allOutbound);
+  const inbound = surviving(allInbound);
+  // Nothing left to show, but the node is not isolated — its peers are simply
+  // filtered out. Saying "isolated" here would be a lie.
+  const hiddenByFilter =
+    outbound.length === 0 && inbound.length === 0 && allOutbound.length + allInbound.length > 0;
+
+  return (
+    <div className="flex flex-col gap-3 text-sm">
+      <div>
+        <h3 className="font-medium break-words">{labels.get(selected) ?? selected}</h3>
+        <p className="text-xs text-mist-500">
+          {node?.user ? `Owned by ${node.user}` : undefined}
+          {node?.user && node.tags.length > 0 ? " · " : undefined}
+          {node && node.tags.length > 0 ? node.tags.join(", ") : undefined}
+          {!node ? "Not a machine" : undefined}
+        </p>
+        <p className="mt-1 text-xs text-mist-500">
+          Reaches {evaluation.reachOut.get(selected)?.length ?? 0} · reached by{" "}
+          {evaluation.reachIn.get(selected)?.length ?? 0}
+        </p>
+      </div>
+
+      <RuleGroup
+        isVisible={isVisible}
+        jumpDisabled={jumpDisabled}
+        onJump={onJump}
+        accent={ACCENT.out}
+        groups={outbound}
+        labels={labels}
+        peerLabel="To"
+        title="Outbound rules"
+      />
+      <RuleGroup
+        isVisible={isVisible}
+        jumpDisabled={jumpDisabled}
+        onJump={onJump}
+        accent={ACCENT.in}
+        groups={inbound}
+        labels={labels}
+        peerLabel="From"
+        title="Inbound rules"
+      />
+
+      {outbound.length === 0 && inbound.length === 0 ? (
+        <p className="text-xs text-mist-500">
+          {hiddenByFilter
+            ? "Every machine this node talks to is filtered out."
+            : direction === "all"
+              ? "No rule mentions this node — it is isolated."
+              : `No ${direction === "in" ? "inbound" : "outbound"} rule applies to this node.`}
+        </p>
+      ) : undefined}
+    </div>
+  );
+}
+
+interface FlowGrouping {
+  src: string;
+  dst: string;
+  rules: { ruleIndex: number; ports: PortRange[]; proto?: string }[];
+}
+
+/**
+ * Traffic permitted between the chosen machines, one entry per direction of
+ * each conversation. Grouped by flow, not by rule: rule-first repeated a pair
+ * once per rule, and again within a card for each dst alias that reached it.
+ * `focus` narrows to one machine's own conversations, for the inspect view.
+ */
+function groupBetween(
+  edges: AclEdge[],
+  chosen: Set<string>,
+  focus: string | null,
+  direction: Direction,
+): FlowGrouping[] {
+  const flows: FlowGrouping[] = [];
+
+  for (const edge of edges) {
+    if (!chosen.has(edge.src) || !chosen.has(edge.dst)) continue;
+    if (focus !== null) {
+      if (direction === "out" && edge.src !== focus) continue;
+      if (direction === "in" && edge.dst !== focus) continue;
+      if (edge.src !== focus && edge.dst !== focus) continue;
+    }
+
+    // One row per rule, even where the rule reaches this flow through several
+    // dst aliases: the ports merge and the row would otherwise repeat.
+    const byRule = new Map<number, FlowGrouping["rules"][number]>();
+    for (const rule of edge.rules) {
+      const entry = byRule.get(rule.ruleIndex) ?? {
+        ruleIndex: rule.ruleIndex,
+        ports: [],
+        proto: rule.proto,
+      };
+      for (const port of rule.ports) {
+        if (!entry.ports.some((p) => p.start === port.start && p.end === port.end)) {
+          entry.ports.push(port);
+        }
+      }
+      byRule.set(rule.ruleIndex, entry);
+    }
+
+    flows.push({
+      src: edge.src,
+      dst: edge.dst,
+      rules: [...byRule.values()].sort((a, b) => a.ruleIndex - b.ruleIndex),
+    });
+  }
+
+  return flows;
+}
+
+function BetweenSummary({
+  chosen,
+  direction,
+  evaluation,
+  jumpDisabled,
+  labels,
+  onJump,
+  selected,
+}: {
+  chosen: Set<string>;
+  direction: Direction;
+  evaluation: AclEvaluation;
+  jumpDisabled: boolean;
+  labels: Map<string, string>;
+  onJump: (ruleIndex: number, token?: string) => void;
+  /** The machine being inspected, if any — the reference for the narrowing. */
+  selected: string | null;
+}) {
+  const name = (id: string) => labels.get(id) ?? id;
+  const flows = groupBetween(evaluation.edges, chosen, selected, direction);
+
+  // Both legs of one conversation sit together, so a two-way pair reads as a
+  // pair instead of turning up twice in unrelated places down the column.
+  const pairName = (flow: FlowGrouping) => [name(flow.src), name(flow.dst)].sort().join(" ");
+  const ordered = [...flows].sort(
+    (a, b) => pairName(a).localeCompare(pairName(b)) || name(a.src).localeCompare(name(b.src)),
+  );
+
+  return (
+    <div className="flex flex-col gap-3 text-sm">
+      <div>
+        <h3 className="font-medium">{chosen.size} machines selected</h3>
+        <p className="text-xs text-mist-500">{[...chosen].map(name).join(", ")}</p>
+      </div>
+
+      {ordered.length === 0 ? (
+        // Said out loud, because the map is still full of lines: those run to
+        // machines outside the selection, and a blank column here would read
+        // as the panel having broken rather than as an answer.
+        <p className="text-xs text-mist-500">
+          {selected
+            ? `No policy connects ${name(selected)} to the other selected machines.`
+            : "No policy connects the selected machines. Their traffic all goes elsewhere — remove one to see what it talks to."}
+        </p>
+      ) : (
+        <div>
+          <h4 className="mb-1 flex items-center gap-1.5 text-xs font-medium">
+            <span className="size-2 rounded-full" style={{ background: ACCENT.selected }} />
+            {selected ? `Flows with ${name(selected)}` : "Flows between them"}
+            <span className="text-mist-500">({ordered.length})</span>
+          </h4>
+          <ul className="divide-y divide-mist-200 dark:divide-mist-800">
+            {ordered.map((flow) => {
+              // Direction only means something against a reference point, so
+              // the rails stay neutral in the overview, where none exists.
+              const accent =
+                selected === null
+                  ? ACCENT.selected
+                  : flow.src === selected
+                    ? ACCENT.out
+                    : ACCENT.in;
+
+              return (
+                <li
+                  className="border-l-2 py-2 pl-2.5 text-xs"
+                  key={`${flow.src}->${flow.dst}`}
+                  style={{ borderColor: accent }}
+                >
+                  <p className="break-words text-mist-900 dark:text-mist-100">
+                    {name(flow.src)} <span className="text-mist-500">→</span> {name(flow.dst)}
+                  </p>
+                  {/* Its rules in succession underneath, which is the shape of
+                      the question: this flow, permitted by these. */}
+                  <ul className="mt-1 space-y-1">
+                    {flow.rules.map((rule) => (
+                      <li className="flex items-center gap-2" key={rule.ruleIndex}>
+                        <RuleBadge index={rule.ruleIndex} />
+                        <span className="ml-auto truncate font-mono text-mist-500">
+                          {rule.proto ?? "any"} · {summarisePorts(rule.ports)}
+                        </span>
+                        <JumpToRule
+                          disabled={jumpDisabled}
+                          onJump={onJump}
+                          ruleIndex={rule.ruleIndex}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface RuleGroupProps {
+  accent: string;
+  isVisible: (id: string) => boolean;
+  jumpDisabled: boolean;
+  onJump: (ruleIndex: number, token?: string) => void;
+  groups: RuleGrouping[];
+  labels: Map<string, string>;
+  /** Prefixes the resolved machines: "To" for outbound, "From" for inbound. */
+  peerLabel: string;
+  title: string;
+}
+
+function RuleGroup({
+  accent,
+  groups,
+  isVisible,
+  jumpDisabled,
+  labels,
+  onJump,
+  peerLabel,
+  title,
+}: RuleGroupProps) {
+  // The panel lists what the canvas is showing, so a filtered-out peer drops
+  // out of the rule that mentions it — and a rule left describing nobody drops
+  // out entirely.
+  const visible = groups
+    .map((group) => ({ ...group, peers: group.peers.filter(isVisible) }))
+    .filter((group) => group.peers.length > 0);
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div>
+      <h4 className="mb-1 flex items-center gap-1.5 text-xs font-medium">
+        <span className="size-2 rounded-full" style={{ background: accent }} />
+        {title}
+        <span className="text-mist-500">({visible.length})</span>
+      </h4>
+      {/*
+        A rail instead of a box. Six boxed cards in a narrow column is 24 border
+        segments all competing with the text; one tinted left edge per row plus
+        a shared hairline reads as a single list — and the tint carries the
+        direction, which otherwise lives only in the header that scrolls away.
+        The rule's own src → dst text is deliberately absent here: when scanning
+        many rules it was noise, and the magnifying glass goes to the source.
+      */}
+      <ul className="divide-y divide-mist-200 dark:divide-mist-800">
+        {visible.map((group) => (
+          <li
+            className="border-l-2 py-2 pl-2.5 text-xs"
+            key={group.ruleIndex}
+            style={{ borderColor: accent }}
+          >
+            <div className="flex items-center gap-2">
+              <RuleBadge index={group.ruleIndex} />
+              <span className="ml-auto truncate font-mono text-mist-500">
+                {group.proto ?? "any"} · {summarisePorts(group.ports)}
+              </span>
+              <JumpToRule disabled={jumpDisabled} onJump={onJump} ruleIndex={group.ruleIndex} />
+            </div>
+            <PeerList label={peerLabel} names={group.peers.map((id) => labels.get(id) ?? id)} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface EdgeSummaryProps {
+  flows: AclEdge[];
+  /** The focused node, so direction can be stated relative to it. */
+  selected: string | null;
+  jumpDisabled: boolean;
+  onJump: (ruleIndex: number, token?: string) => void;
+  evaluation: AclEvaluation;
+  labels: Map<string, string>;
+  onClose: () => void;
+}
+
+function EdgeSummary({
+  evaluation,
+  flows,
+  jumpDisabled,
+  labels,
+  onJump,
+  onClose,
+  selected,
+}: EdgeSummaryProps) {
+  const name = (id: string) => labels.get(id) ?? id;
+  const [first] = flows;
+  const twoWay = flows.length > 1;
+
+  // Direction only means something relative to a node. In the focused view
+  // that is the node being inspected, so a leg leaving it is outbound and
+  // takes the same emerald the map and the node summary use. The overview has
+  // no such reference point, so both legs stay neutral there.
+  const accentFor = (flow: AclEdge) =>
+    selected === null ? ACCENT.selected : flow.src === selected ? ACCENT.out : ACCENT.in;
+
+  return (
+    <div className="text-sm">
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <span className="font-medium break-words">
+          {name(first.src)} {twoWay ? "↔" : "→"} {name(first.dst)}
+        </span>
+        <button aria-label="Close flow details" onClick={onClose} type="button">
+          <X className="size-4" />
+        </button>
+      </div>
+
+      {/*
+        One section per direction. Rules can exist both ways between the same
+        pair, and which way a rule runs is the whole question — so each section
+        states its own source → destination rather than relying on the header,
+        which cannot describe both at once.
+      */}
+      {flows.map((flow) => (
+        <div className="mb-3 last:mb-0" key={edgeId(flow)}>
+          {twoWay ? (
+            <h4 className="mb-1 flex items-center gap-1.5 font-mono text-xs break-words text-mist-500">
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ background: accentFor(flow) }}
+              />
+              {name(flow.src)} → {name(flow.dst)}
+            </h4>
+          ) : undefined}
+          <ul className="divide-y divide-mist-200 dark:divide-mist-800">
+            {mergeFlowRules(flow.rules).map((rule) => {
+              const source = evaluation.rules.find((r) => r.index === rule.ruleIndex);
+              return (
+                <li
+                  className="border-l-2 py-2 pl-2.5 text-xs"
+                  key={rule.ruleIndex}
+                  style={{ borderColor: accentFor(flow) }}
+                >
+                  <div className="flex items-center gap-2">
+                    <RuleBadge index={rule.ruleIndex} />
+                    {/*
+                      Protocol only. This card lists the ports in full below,
+                      and `summarisePorts` prints values rather than a count at
+                      three or fewer — so a short rule said "any · 9200, 9300,
+                      9980" and then said it again two lines down.
+                    */}
+                    <span className="ml-auto truncate font-mono text-mist-500">
+                      {rule.proto ?? "any"}
+                    </span>
+                    <JumpToRule
+                      disabled={jumpDisabled}
+                      onJump={onJump}
+                      ruleIndex={rule.ruleIndex}
+                    />
+                  </div>
+                  {/*
+                    Endpoints as the policy writes them — but only the dst
+                    tokens that actually matched this flow. Printing the rule's
+                    whole dst list buried the card in destinations belonging to
+                    other pairs.
+                  */}
+                  {source ? (
+                    <p className="mt-1 font-mono break-words text-mist-500">
+                      {source.src.join(", ")} → {rule.dstAliases.join(", ")}
+                    </p>
+                  ) : undefined}
+                  <PortList ports={rule.ports} />
+                </li>
+              );
+            })}
+          </ul>
+          {isSubnetNodeId(flow.dst) ? (
+            <p className="mt-2 text-xs text-mist-500">
+              {subnetRoutersFor(evaluation, flow.dst).length > 0
+                ? `Routed by ${subnetRoutersFor(evaluation, flow.dst).map(name).join(", ")}`
+                : "No machine advertises an approved route covering this subnet."}
+            </p>
+          ) : undefined}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function subnetRoutersFor(evaluation: AclEvaluation, id: string): string[] {
+  return evaluation.subnets.find((subnet) => subnet.id === id)?.routers ?? [];
+}
+
+interface FlowRule {
+  ruleIndex: number;
+  proto?: string;
+  ports: PortRange[];
+  dstAliases: string[];
+}
+
+/**
+ * One card per rule, not per matched destination. A rule naming several dsts
+ * that all resolve to the same machine produced a separate identical-looking
+ * card for each; the ports and matched tokens belong together.
+ */
+function mergeFlowRules(rules: EdgeRule[]): FlowRule[] {
+  const byIndex = new Map<number, FlowRule>();
+
+  for (const rule of rules) {
+    const existing = byIndex.get(rule.ruleIndex);
+    if (existing) {
+      existing.ports.push(...rule.ports);
+      if (!existing.dstAliases.includes(rule.dstAlias)) existing.dstAliases.push(rule.dstAlias);
+    } else {
+      byIndex.set(rule.ruleIndex, {
+        ruleIndex: rule.ruleIndex,
+        proto: rule.proto,
+        ports: [...rule.ports],
+        dstAliases: [rule.dstAlias],
+      });
+    }
+  }
+
+  return [...byIndex.values()].sort((a, b) => a.ruleIndex - b.ruleIndex);
+}
+
+/**
+ * The ports a flow permits: the payload of the card, so it takes the
+ * full-strength colour. Capped by token count rather than by lines, since how
+ * many fit on a line depends on the panel width.
+ */
+function PortList({ ports }: { ports: PortRange[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const tokens = portTokens(ports);
+  const limit = 8;
+  const hidden = tokens.length - limit;
+  const shown = expanded || hidden <= 0 ? tokens : tokens.slice(0, limit);
+
+  if (tokens.length === 0) return null;
+
+  return (
+    <p className="mt-1 font-mono break-words text-mist-900 dark:text-mist-100">
+      {shown.join(", ")}
+      {hidden > 0 ? (
+        <button
+          className="ml-1 rounded font-sans text-mist-500 underline underline-offset-2 hover:text-mist-700 dark:hover:text-mist-300"
+          onClick={() => setExpanded((current) => !current)}
+          type="button"
+        >
+          {expanded ? "show less" : `+${hidden} more`}
+        </button>
+      ) : undefined}
+    </p>
+  );
+}
+
+/**
+ * Open this rule in the editor. Icon only, and it sits on the card's header
+ * line — the label was identical on every card, so spelling it out added a
+ * whole row of repeated text per rule.
+ */
+function JumpToRule({
+  disabled,
+  onJump,
+  ruleIndex,
+  token,
+}: {
+  disabled?: boolean;
+  onJump: (index: number, token?: string) => void;
+  ruleIndex: number;
+  token?: string;
+}) {
+  // Rendered as a plain icon rather than a disabled <button>: the tooltip's
+  // own trigger is a button (so nesting one would be invalid), and a natively
+  // disabled control often swallows the hover that would explain itself.
+  if (disabled) {
+    return (
+      <Tooltip content="Save or discard the ACL to use this tool">
+        <span
+          aria-disabled="true"
+          aria-label="Show in the policy file — save or discard first"
+          className="shrink-0 cursor-not-allowed rounded p-1 text-mist-300 dark:text-mist-700"
+        >
+          <Search className="size-3.5" />
+        </span>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <button
+      aria-label={`Show acls[${ruleIndex}] in the policy file`}
+      className={cn(
+        "shrink-0 rounded p-1 text-mist-500",
+        "hover:bg-mist-100 hover:text-mist-700",
+        "dark:hover:bg-mist-800 dark:hover:text-mist-300",
+      )}
+      onClick={() => onJump(ruleIndex, token)}
+      title="Show this rule in the policy file"
+      type="button"
+    >
+      <Search className="size-3.5" />
+    </button>
+  );
+}
+
+/**
+ * A square icon control that keeps its explanation when disabled. Uses `title`
+ * rather than `~/components/tooltip`, whose trigger is itself a button; the
+ * disabled form is a span, since a disabled button swallows the hover that
+ * would explain why.
+ */
+function IconButton({
+  active = false,
+  children,
+  disabled = false,
+  label,
+  onClick,
+}: {
+  /** On, in the switch sense: tinted so the state reads without the tooltip. */
+  active?: boolean;
+  children: React.ReactNode;
+  disabled?: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  const shell = cn(
+    // Opts back in: the panel wrapping these is pointer-events-none so its
+    // empty area stays part of the map.
+    "pointer-events-auto flex items-center rounded-md border p-1.5",
+    active
+      ? "border-indigo-400/60 bg-indigo-500/10 text-indigo-500 dark:border-indigo-500/50 dark:text-indigo-400"
+      : "border-mist-200 bg-mist-50/85 dark:border-mist-800 dark:bg-mist-950/85",
+  );
+
+  if (disabled) {
+    return (
+      <span aria-disabled className={cn(shell, "text-mist-400 dark:text-mist-600")} title={label}>
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      aria-label={label}
+      className={cn(
+        shell,
+        active ? "hover:bg-indigo-500/20" : "hover:bg-mist-100 dark:hover:bg-mist-900",
+      )}
+      onClick={onClick}
+      title={label}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}
+
+interface FilterItem {
+  id: string;
+  label: string;
+  /** Owner and tags, shown under the name to tell similar machines apart. */
+  detail: string;
+  /** Pre-lowercased name, owner, tags and addresses, for the search box. */
+  haystack: string;
+}
+
+/** Clear of the canvas edge, so the panel never runs flush into the border. */
+const PANEL_EDGE_GAP = 24;
+
+/**
+ * Drag the bottom-right corner to grow the picker. Right and down only: the
+ * panel is anchored top-left, so the other way would have to move it. Floored
+ * at its natural size (captured on the first drag) and ceilinged at the canvas
+ * edge. Not persisted — a scratch adjustment for one search.
+ */
+function usePanelResize() {
+  const ref = useRef<HTMLDivElement>(null);
+  const natural = useRef<{ width: number; height: number } | null>(null);
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+
+  const onResizeStart = (event: React.PointerEvent<HTMLElement>) => {
+    const panel = ref.current;
+    if (!panel) return;
+    event.preventDefault();
+    // Or the canvas beneath treats it as a background click and steps back.
+    event.stopPropagation();
+
+    const start = panel.getBoundingClientRect();
+    // Before the first drag the panel is at its natural size, so this is the
+    // smallest it can honestly go.
+    natural.current ??= { width: start.width, height: start.height };
+    const min = natural.current;
+
+    const canvas = panel.closest(".react-flow")?.getBoundingClientRect();
+    const maxWidth = canvas ? canvas.right - start.left - PANEL_EDGE_GAP : Number.POSITIVE_INFINITY;
+    const maxHeight = canvas
+      ? canvas.bottom - start.top - PANEL_EDGE_GAP
+      : Number.POSITIVE_INFINITY;
+
+    const handle = event.currentTarget;
+    const startX = event.clientX;
+    const startY = event.clientY;
+    // Capture, so a fast drag that outruns the 12px handle keeps resizing
+    // instead of dropping the gesture over the canvas.
+    handle.setPointerCapture(event.pointerId);
+
+    const clamp = (value: number, low: number, high: number) =>
+      Math.max(low, Math.min(value, high));
+
+    const onMove = (move: PointerEvent) => {
+      setSize({
+        width: clamp(start.width + (move.clientX - startX), min.width, maxWidth),
+        height: clamp(start.height + (move.clientY - startY), min.height, maxHeight),
+      });
+    };
+
+    const onUp = () => {
+      // Only if it is still held: the browser releases implicitly, and calling
+      // this on a pointer it no longer has throws NotFoundError — which would
+      // abort the handler before the listeners came off and leave the panel
+      // resizing after the button was let go.
+      if (handle.hasPointerCapture(event.pointerId)) {
+        handle.releasePointerCapture(event.pointerId);
+      }
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      // A cancelled gesture (a touch turning into a scroll, the tab losing the
+      // pointer) never sends pointerup, so without this the listeners stay.
+      handle.removeEventListener("pointercancel", onUp);
+    };
+
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
+    handle.addEventListener("pointercancel", onUp);
+  };
+
+  return { size, onResizeStart, ref };
+}
+
+interface FilterPanelProps {
+  machines: FilterItem[];
+  extras: FilterItem[];
+  chosen: Set<string>;
+  animateAll: boolean;
+  suspended: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onToggle: (id: string) => void;
+  /** Tick or untick a whole set at once — every search hit, in practice. */
+  onToggleMany: (ids: string[], selected: boolean) => void;
+  onChange: (updates: Partial<Record<FilterKey, string | null>>) => void;
+}
+
+/**
+ * Pick which machines the map lights. Nothing chosen means everything, so
+ * "clear" and "select all" are one state and the canvas can never end up
+ * empty by accident. Collapsed by default, since an open roster covers the map
+ * it exists to help you read. The search narrows this list only, never the
+ * ticks, so clearing the term leaves the selection alone.
+ */
+function FilterPanel({
+  machines,
+  extras,
+  chosen,
+  animateAll,
+  suspended,
+  open,
+  onOpenChange,
+  onToggle,
+  onToggleMany,
+  onChange,
+}: FilterPanelProps) {
+  const [search, setSearch] = useState("");
+  const { size, onResizeStart, ref: panelRef } = usePanelResize();
+
+  const term = search.trim().toLowerCase();
+  const matches = (item: FilterItem) => term.length === 0 || item.haystack.includes(term);
+  const unchosen = (items: FilterItem[]) =>
+    items.filter((item) => !chosen.has(item.id) && matches(item));
+
+  // Everything the term matches, chosen or not — a hit is a hit, and the ticked
+  // ones are pinned to the top of the list whether or not they match. With no
+  // term there is nothing to act on in bulk: "select all" over the whole roster
+  // is the same as choosing nothing, which is already the default.
+  const hits = term.length === 0 ? [] : [...machines, ...extras].filter(matches);
+  const allHitsChosen = hits.length > 0 && hits.every((item) => chosen.has(item.id));
+
+  // Chosen items ignore the search and pin to the top, or ticking one and then
+  // retyping would hide it with no way to untick it.
+  const picked = [...machines, ...extras].filter((item) => chosen.has(item.id));
+  const restMachines = unchosen(machines);
+  const restExtras = unchosen(extras);
+
+  const row = (item: FilterItem) => (
+    <label
+      className="flex cursor-pointer items-start gap-2 rounded px-1 py-0.5 hover:bg-mist-100 dark:hover:bg-mist-800"
+      key={item.id}
+    >
+      <input
+        checked={chosen.has(item.id)}
+        className="mt-0.5"
+        onChange={() => onToggle(item.id)}
+        type="checkbox"
+      />
+      <span className="min-w-0">
+        <span className="block truncate">{item.label}</span>
+        {item.detail ? (
+          <span className="block truncate text-[11px] text-mist-500">{item.detail}</span>
+        ) : undefined}
+      </span>
+    </label>
+  );
+
+  if (!open) {
+    return (
+      <button
+        className={cn(
+          "pointer-events-auto flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs",
+          "border-mist-200 bg-mist-50/85 dark:border-mist-800 dark:bg-mist-950/85",
+          "hover:bg-mist-100 dark:hover:bg-mist-900",
+        )}
+        onClick={() => onOpenChange(true)}
+        type="button"
+      >
+        <ListFilter className="size-3.5" />
+        Filter
+        {chosen.size > 0 ? (
+          <span className={cn("rounded px-1", suspended ? "text-mist-500" : "text-indigo-500")}>
+            {chosen.size}
+          </span>
+        ) : undefined}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-auto relative flex flex-col gap-1.5 rounded-md border p-2 text-xs",
+        "border-mist-200 bg-mist-50/95 dark:border-mist-800 dark:bg-mist-950/95",
+        // Sized to the longest name and tag list so nothing truncates at rest,
+        // floored so a short roster is not cramped and ceilinged so one long
+        // tag cannot take the canvas. Only until the first drag.
+        size === null ? "w-max min-w-60 max-w-md" : undefined,
+      )}
+      onClick={(event) => event.stopPropagation()}
+      ref={panelRef}
+      style={size ?? undefined}
+    >
+      <div className="flex items-center gap-1.5">
+        <Search className="size-3.5 shrink-0 text-mist-500" />
+        <input
+          aria-label="Search machines"
+          className="min-w-0 flex-1 bg-transparent outline-none placeholder:text-mist-500"
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Name, tag, owner or IP"
+          value={search}
+        />
+        {/* Clears the term first and closes only once there is nothing to
+            clear. Sitting inside the search field it reads as the field's own
+            clear button, so closing the whole panel on the first press loses
+            work the user was in the middle of. Same progressive dismissal as
+            the background click, which closes this panel before it touches the
+            selection behind it. */}
+        <button
+          aria-label={search.length > 0 ? "Clear the search" : "Close the filter"}
+          className="shrink-0 rounded p-0.5 text-mist-500 hover:text-mist-700 dark:hover:text-mist-300"
+          onClick={() => {
+            if (search.length > 0) setSearch("");
+            else onOpenChange(false);
+          }}
+          title={search.length > 0 ? "Clear the search" : "Close the filter"}
+          type="button"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      {hits.length > 0 ? (
+        <div className="flex items-center justify-between gap-2 text-[11px] text-mist-500">
+          <span>
+            {hits.length} {hits.length === 1 ? "match" : "matches"}
+          </span>
+          {/* One call, not a loop of single toggles: each of those would read
+              the same stale `chosen` and only the last would survive. */}
+          <button
+            className="rounded underline underline-offset-2 hover:text-mist-700 dark:hover:text-mist-300"
+            onClick={() =>
+              onToggleMany(
+                hits.map((item) => item.id),
+                !allHitsChosen,
+              )
+            }
+            type="button"
+          >
+            {allHitsChosen ? "deselect all" : "select all"}
+          </button>
+        </div>
+      ) : undefined}
+
+      {/* Capped until resized, then it takes whatever the drag gave it — the
+          list is the only part worth growing. `min-h-0` or a flex child
+          refuses to shrink below its content and the panel overflows.
+          20rem holds eight rows of name-plus-tags with room for a group
+          heading, which is enough to compare machines without scrolling. */}
+      <div className={cn("overflow-y-auto", size === null ? "max-h-80" : "min-h-0 flex-1")}>
+        {picked.length > 0 ? (
+          <>
+            <p className="px-1 py-0.5 text-[11px] text-mist-500">Selected ({picked.length})</p>
+            {picked.map(row)}
+            <hr className="my-1 border-mist-200 dark:border-mist-800" />
+          </>
+        ) : undefined}
+
+        {restMachines.map(row)}
+
+        {restExtras.length > 0 ? (
+          <>
+            <p className="px-1 py-0.5 text-[11px] text-mist-500">Internet &amp; subnets</p>
+            {restExtras.map(row)}
+          </>
+        ) : undefined}
+
+        {picked.length === 0 && restMachines.length === 0 && restExtras.length === 0 ? (
+          <p className="px-1 py-1 text-mist-500">Nothing matches “{search}”.</p>
+        ) : undefined}
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-mist-200 pt-1.5 dark:border-mist-800">
+        {/* Says so plainly: suspended is the state in which none of the filter
+            controls below do anything, and a bare count does not hint at it.
+            Suspending and clearing themselves live in the toolbar now. */}
+        <span className="text-mist-500">
+          {chosen.size === 0
+            ? "Showing all"
+            : suspended
+              ? `${chosen.size} selected · suspended`
+              : `${chosen.size} selected`}
+        </span>
+      </div>
+
+      {/* Hiding moved out to the toolbar beside suspend and clear — all three
+          act on the filter as a whole. What is left here only changes how the
+          map is drawn, never what it contains. */}
+      <div className="flex flex-col gap-1 text-mist-500">
+        <label
+          className="flex cursor-pointer items-center gap-1.5"
+          title="Keep every line moving, not just the ones you point at or pick"
+        >
+          <input
+            checked={animateAll}
+            onChange={(event) => onChange({ animate: event.target.checked ? "1" : null })}
+            type="checkbox"
+          />
+          Animate all flows
+        </label>
+      </div>
+
+      {/*
+        Two hairlines in the corner, the conventional grip. A button rather
+        than a div so it is focusable and announced; the pointer handler does
+        the work, and there is nothing for a plain activation to do.
+      */}
+      <button
+        aria-label="Resize the filter panel"
+        className={cn(
+          "absolute right-0.5 bottom-0.5 size-3 cursor-nwse-resize rounded-xs",
+          "border-mist-400 border-r-2 border-b-2 opacity-40 hover:opacity-80 dark:border-mist-600",
+        )}
+        onPointerDown={onResizeStart}
+        title="Drag to resize"
+        type="button"
+      />
+    </div>
+  );
+}
+
+/** A fixed anchor to scan down: every card starts with its rule id. */
+function RuleBadge({ index }: { index: number }) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded px-1.5 py-0.5 font-mono text-[11px]",
+        "bg-mist-100 text-mist-600 dark:bg-mist-800 dark:text-mist-300",
+      )}
+    >
+      acls[{index}]
+    </span>
+  );
+}
+
+/**
+ * The machines a rule resolved to, labelled with the direction so they are not
+ * confused with the rule's own src → dst aliases directly above. Capped,
+ * because one wildcard rule would otherwise dump the whole tailnet into the
+ * panel.
+ */
+function PeerList({ label, names }: { label: string; names: string[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const limit = 3;
+  const hidden = names.length - limit;
+  const shown = expanded || hidden <= 0 ? names : names.slice(0, limit);
+
+  return (
+    <p className="mt-1 break-words">
+      {/*
+        Machines carry the full-strength colour and ports stay muted monospace,
+        so the two kinds of value in a card are told apart at a glance rather
+        than read.
+      */}
+      <span className="text-mist-500">{label} </span>
+      <span className="text-mist-900 dark:text-mist-100">{shown.join(", ")}</span>
+      {hidden > 0 ? (
+        <button
+          className="ml-1 rounded text-mist-500 underline underline-offset-2 hover:text-mist-700 dark:hover:text-mist-300"
+          onClick={() => setExpanded((current) => !current)}
+          type="button"
+        >
+          {expanded ? "show less" : `+${hidden} more`}
+        </button>
+      ) : undefined}
+    </p>
+  );
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+interface OverviewEdgeState {
+  /** Run this line whether or not it is emphasised. */
+  alwaysAnimate: boolean;
+  /** Arrowhead at the target end — the directed views always, plus emphasis. */
+  arrowEnd: boolean;
+  /** Overrides the emphasis colour, for the legend's direction accents. */
+  colour?: string;
+  /** Perpendicular offset, so the two legs of a pair sit side by side. */
+  lane: number;
+  /** The cursor is on this line. */
+  hovered: boolean;
+  /** Nothing is hovered, so nothing is emphasised. */
+  idle: boolean;
+  /** Runs to or from the hovered node, in the filtered direction. */
+  lit: boolean;
+  /** Some OTHER line is under the cursor, so this one gets out of its way. */
+  otherHovered: boolean;
+  /** Clicked; stays emphasised until cleared. */
+  selected: boolean;
+  /** Some line is selected, so the rest recede. */
+  someSelected: boolean;
+  /** Filtered out: drawn faintly, and clicking it adds both its machines. */
+  muted: boolean;
+}
+
+/** One overview line: straight, between the nearest points on each box. */
+function overviewEdge(edge: AclEdge, state: OverviewEdgeState): Edge {
+  const emphasised = state.selected || state.hovered || state.lit;
+  const colour = state.colour ?? (emphasised ? ACCENT.selected : ACCENT.idle);
+  return {
+    id: edgeId(edge),
+    source: edge.src,
+    target: edge.dst,
+    // Straight lines between the nearest points on each box, rather than
+    // beziers between fixed handles — far less noodly on a ring.
+    type: "floating",
+    // Unused by the floating edge, but they must reference real handles or
+    // React Flow will not resolve the edge.
+    sourceHandle: HANDLE.source,
+    targetHandle: HANDLE.target,
+    markerEnd: state.arrowEnd ? { type: MarkerType.ArrowClosed, color: colour } : undefined,
+    // Movement follows emphasis, or the idle graph is constant noise — unless
+    // asked for, and "animate all flows" means all of them, greyed included.
+    // Each leg travels its own way, so React Flow's own flag is enough.
+    animated: state.alwaysAnimate || emphasised,
+    data: { lane: state.lane },
+    style: {
+      stroke: colour,
+      strokeWidth: state.hovered ? 3 : state.selected ? 3 : state.lit ? 2 : 1,
+      // A selection persists; hover still wins over the fade, so a dimmed line
+      // stays findable under the cursor.
+      opacity: state.muted
+        ? // Level with a greyed node rather than the old near-invisible 0.04:
+          // this is a click target now, so it has to be findable, and hover
+          // lifts it further to say the click will land.
+          state.hovered || state.lit
+          ? 0.6
+          : DIMMED_OPACITY
+        : // Hover comes first and goes to full strength, with everything else
+          // pushed well back below. Lit lines already sit at 0.95, so the old
+          // order left hovering one of them changing almost nothing — the
+          // contrast has to come from the rest receding, not from the line
+          // brightening the last 5%.
+          state.hovered
+          ? 1
+          : state.otherHovered
+            ? 0.1
+            : state.selected
+              ? 1
+              : state.someSelected
+                ? 0.08
+                : // Ahead of `idle`: a chosen machine's traffic is lit with no
+                  // cursor anywhere, so the two are no longer exclusive.
+                  state.lit
+                  ? 0.95
+                  : state.idle
+                    ? 0.4
+                    : 0.05,
+      cursor: "pointer",
+      transition: "opacity 120ms ease, stroke-width 120ms ease",
+    },
+  };
+}
+
+interface RuleGrouping {
+  ruleIndex: number;
+  peers: string[];
+  ports: PortRange[];
+  proto?: string;
+}
+
+/** Collapse the edges touching `selected` into one entry per ACL rule. */
+function groupByRule(edges: AclEdge[], selected: string, dir: "out" | "in"): RuleGrouping[] {
+  const grouped = new Map<number, { peers: Set<string>; ports: PortRange[]; proto?: string }>();
+
+  for (const edge of edges) {
+    const matches = dir === "out" ? edge.src === selected : edge.dst === selected;
+    if (!matches) continue;
+    const peer = dir === "out" ? edge.dst : edge.src;
+
+    for (const rule of edge.rules) {
+      const entry = grouped.get(rule.ruleIndex) ?? {
+        peers: new Set<string>(),
+        ports: [],
+        proto: rule.proto,
+      };
+      entry.peers.add(peer);
+      for (const port of rule.ports) {
+        if (!entry.ports.some((p) => p.start === port.start && p.end === port.end)) {
+          entry.ports.push(port);
+        }
+      }
+      grouped.set(rule.ruleIndex, entry);
+    }
+  }
+
+  return [...grouped.entries()]
+    .map(([ruleIndex, entry]) => ({
+      ruleIndex,
+      peers: [...entry.peers],
+      ports: entry.ports,
+      proto: entry.proto,
+    }))
+    .sort((a, b) => a.ruleIndex - b.ruleIndex);
+}
+
+interface NodeOptions {
+  dim?: boolean;
+  /** Only ever false for the node being inspected: clicking it is a no-op. */
+  interactive?: boolean;
+  /**
+   * Whether a click would change the filter. Separate from `interactive`,
+   * which governs pointer events: a node with a frozen selection still hovers
+   * to show its flows, it just no longer offers a pointer.
+   */
+  selectable?: boolean;
+  /** Omitted for the inspected node, which has nowhere to go. */
+  onInspect?: (id: string) => void;
+}
+
+function buildNode(
+  id: string,
+  labels: Map<string, string>,
+  role: Role,
+  position: { x: number; y: number },
+  { dim = false, interactive = true, selectable = true, onInspect }: NodeOptions = {},
+): Node {
+  return {
+    id,
+    position,
+    type: "flow",
+    // On the wrapper, not just the inner box: React Flow's node element is
+    // what receives the pointer, so styling the child alone still leaves the
+    // node hoverable.
+    style: interactive ? undefined : { pointerEvents: "none" },
+    data: {
+      label: labels.get(id) ?? id,
+      role,
+      pseudo: isPseudo(id),
+      dim,
+      interactive,
+      selectable,
+      onInspect,
+    },
+  };
+}
+
+interface FocusEdgeStyle {
+  colour: string;
+  animated: boolean;
+  opacity: number;
+  strokeWidth: number;
+  arrowEnd: boolean;
+  /** Head at the near end too, for a two-way conversation. */
+  arrowStart: boolean;
+  /** Two-way: drawn by DualFlowEdge so both directions animate at once. */
+  dual: boolean;
+  /** Runs to a filtered-out node, so it recedes to match it. */
+  muted: boolean;
+}
+
+function buildEdge(edge: AclEdge, state: FocusEdgeStyle): Edge {
+  const marker = { type: MarkerType.ArrowClosed, color: state.colour };
+  // "Animate all flows" means all of them, greyed ones included: they are
+  // click targets, not inert decoration, and leaving them still made the
+  // toggle look half-applied.
+  const animated = state.animated;
+  return {
+    id: edgeId(edge),
+    source: edge.src,
+    target: edge.dst,
+    sourceHandle: HANDLE.source,
+    targetHandle: HANDLE.target,
+    type: state.dual ? "dual" : undefined,
+    // A dual edge animates itself; React Flow's own flag only moves one way
+    // and would fight the two streams.
+    animated: state.dual ? false : animated,
+    data: state.dual ? { active: animated } : undefined,
+    markerEnd: state.arrowEnd ? marker : undefined,
+    markerStart: state.arrowStart ? marker : undefined,
+    style: {
+      stroke: state.colour,
+      strokeWidth: state.strokeWidth,
+      // Level with a greyed node. Clicking it adds both its machines to the
+      // filter rather than opening rules, so it stays a live target.
+      opacity: state.muted ? DIMMED_OPACITY : state.opacity,
+      cursor: "pointer",
+      // Keeps the fade from strobing as the cursor crosses several lines.
+      transition: "opacity 120ms ease, stroke-width 120ms ease",
+    },
+  };
+}
+
+/**
+ * Mirror the app's theme onto React Flow, which styles its own controls and
+ * background. Headplane puts an explicit `.dark`/`.light` on <html> and
+ * otherwise follows the system preference — the same three states React Flow
+ * accepts, so this maps across directly.
+ */
+function useColorMode(): "light" | "dark" | "system" {
+  const [mode, setMode] = useState<"light" | "dark" | "system">("system");
+
+  useEffect(() => {
+    const read = () => {
+      const classes = document.documentElement.classList;
+      setMode(classes.contains("dark") ? "dark" : classes.contains("light") ? "light" : "system");
+    };
+
+    read();
+    const observer = new MutationObserver(read);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+
+  return mode;
+}
+
+function Legend({ colour, children }: { colour: string; children: React.ReactNode }) {
+  return (
+    <span className="flex items-center gap-1.5 whitespace-nowrap">
+      <span className="size-2.5 shrink-0 rounded-full" style={{ background: colour }} />
+      {children}
+    </span>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-md border border-mist-200 dark:border-mist-800"
+      style={{ height: MAP_HEIGHT }}
+    >
+      <div className="flex h-full items-center justify-center">
+        <p className="max-w-prose text-center text-sm text-mist-500">{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function edgeId(edge: AclEdge): string {
+  return `${edge.src}->${edge.dst}`;
+}
+
+/** Direction-independent key for a node pair, so both legs share an identity. */
+function pairKey(a: string, b: string): string {
+  return [a, b].sort().join(" ");
+}
+
+function isPseudo(id: string): boolean {
+  return id === INTERNET || isSubnetNodeId(id);
+}

--- a/app/routes/acls/overview.tsx
+++ b/app/routes/acls/overview.tsx
@@ -1,6 +1,23 @@
-import { AlertCircle, Construction, Eye, FlaskConical, Pencil } from "lucide-react";
-import { Suspense, lazy, useEffect, useState } from "react";
-import { isRouteErrorResponse, useFetcher, useRevalidator } from "react-router";
+import {
+  AlertCircle,
+  CircleX,
+  Construction,
+  Eye,
+  FlaskConical,
+  Pencil,
+  Share2,
+} from "lucide-react";
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
+// Aliased: this module also exports a route-level ErrorBoundary, which is the
+// thing we are specifically trying not to reach.
+import { ErrorBoundary as RenderErrorBoundary } from "react-error-boundary";
+import {
+  isRouteErrorResponse,
+  type ShouldRevalidateFunction,
+  useFetcher,
+  useRevalidator,
+  useSearchParams,
+} from "react-router";
 
 import Button from "~/components/button";
 import Card from "~/components/card";
@@ -10,6 +27,7 @@ import Notice from "~/components/notice";
 import PageError from "~/components/page-error";
 import { Tabs, TabsList, TabsPanel, TabsTab } from "~/components/tabs";
 import { isApiError } from "~/server/headscale/api/error-client";
+import { locateRules, locateRuleToken } from "~/utils/acl/locate";
 import toast from "~/utils/toast";
 
 import type { Route } from "./+types/overview";
@@ -23,15 +41,114 @@ const LazyEditor = lazy(() =>
 const LazyDiffer = lazy(() =>
   import("./components/cm.client").then((m) => ({ default: m.Differ })),
 );
+const LazyMap = lazy(() =>
+  import("./components/map.client").then((m) => ({ default: m.ReachabilityMap })),
+);
 
 export const loader = aclLoader;
 export const action = aclAction;
 
-export default function Page({ loaderData: { access, writable, policy } }: Route.ComponentProps) {
+/** Must list every <TabsTab value>, or that tab cannot be selected. */
+const TAB_VALUES = ["edit", "diff", "preview", "map"] as const;
+type TabValue = (typeof TAB_VALUES)[number];
+
+function isTabValue(value: string | null): value is TabValue {
+  return value !== null && (TAB_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * The reachability map stores its selection in the URL so browser back/forward
+ * navigate between focused nodes. Those params are purely client-side, so a
+ * node click must not refetch the policy and machine list — and must not
+ * disturb the unsaved editor buffer. Anything else (including the explicit
+ * revalidation after a save) still goes through as normal.
+ */
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  currentUrl,
+  nextUrl,
+  formMethod,
+  defaultShouldRevalidate,
+}) => {
+  if (formMethod !== undefined) return defaultShouldRevalidate;
+
+  const uiParams = ["node", "flow", "edge", "tab", "rule", "token", "only", "hide", "qoff", "anim"];
+  const mapParamsChanged = uiParams.some(
+    (param) => currentUrl.searchParams.get(param) !== nextUrl.searchParams.get(param),
+  );
+  if (!mapParamsChanged) return defaultShouldRevalidate;
+
+  // Only skip when those client-side params are the *only* thing that changed.
+  const withoutMapParams = (url: URL) => {
+    const params = new URLSearchParams(url.searchParams);
+    for (const param of uiParams) params.delete(param);
+    return `${url.pathname}?${params.toString()}`;
+  };
+
+  return withoutMapParams(currentUrl) !== withoutMapParams(nextUrl);
+};
+
+export default function Page({
+  loaderData: { access, writable, policy, nodes },
+}: Route.ComponentProps) {
   const [codePolicy, setCodePolicy] = useState(policy);
   const fetcher = useFetcher<typeof action>();
   const { revalidate } = useRevalidator();
+  const [searchParams, setSearchParams] = useSearchParams();
   const disabled = !access || !writable; // Disable if no permission or not writable
+
+  // The tab lives in the URL so that "show this rule in the file" is a real
+  // history entry: Back returns to the map tab with its selection intact.
+  // Every tab value must round-trip — treating anything that is not "map" as
+  // "edit" made the diff and preview tabs unselectable.
+  const tabParam = searchParams.get("tab");
+  const tab: TabValue = isTabValue(tabParam) ? tabParam : "edit";
+
+  // Ranges are scanned from the LIVE buffer, not the saved policy — unsaved
+  // edits shift every offset, and highlighting the wrong rule is worse than
+  // not highlighting at all.
+  //
+  // The buffer is deliberately read through a ref rather than being a
+  // dependency: locateRules walks the whole policy, the result is consumed
+  // once per jump, and depending on the text would rescan on every keystroke
+  // for as long as the params stayed in the URL.
+  const bufferRef = useRef(codePolicy);
+  bufferRef.current = codePolicy;
+
+  const ruleRaw = searchParams.get("rule");
+  const tokenParam = searchParams.get("token");
+  const ruleParam = Number(ruleRaw);
+  const highlight = useMemo(() => {
+    if (ruleRaw === null || !Number.isInteger(ruleParam)) return undefined;
+    const buffer = bufferRef.current;
+    try {
+      const rule = locateRules(buffer).find((range) => range.index === ruleParam);
+      if (!rule) return undefined;
+      // Narrow to the offending token when one was named; fall back to the
+      // whole rule if it cannot be found, e.g. after an edit moved it.
+      if (tokenParam) return locateRuleToken(buffer, rule, tokenParam) ?? rule;
+      return rule;
+    } catch {
+      // Scanning someone else's policy should never take the page down.
+      return undefined;
+    }
+  }, [ruleRaw, ruleParam, tokenParam]);
+
+  const selectTab = (next: string | number) => {
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        // "edit" is the default, so it stays out of the URL.
+        if (next === "edit") params.delete("tab");
+        else params.set("tab", String(next));
+        // A highlight belongs to one visit to the editor, not to the tab.
+        params.delete("rule");
+        params.delete("token");
+        return params;
+      },
+      // Replace: switching tabs by hand is not a step worth retracing.
+      { preventScrollReset: true, replace: true },
+    );
+  };
 
   useEffect(() => {
     // Update the codePolicy when the loader data changes
@@ -86,7 +203,7 @@ export default function Page({ loaderData: { access, writable, policy } }: Route
             "An unknown error occurred while trying to update the ACL policy."}
         </Notice>
       ) : undefined}
-      <Tabs className="mb-4" label="ACL Editor" defaultValue="edit">
+      <Tabs className="mb-4" label="ACL Editor" onValueChange={selectTab} value={tab}>
         <TabsList>
           <TabsTab value="edit">
             <div className="flex items-center gap-2">
@@ -106,10 +223,24 @@ export default function Page({ loaderData: { access, writable, policy } }: Route
               <span>Preview rules</span>
             </div>
           </TabsTab>
+          <TabsTab value="map">
+            <div className="flex items-center gap-2">
+              <Share2 className="p-1" />
+              <span>Reachability map</span>
+            </div>
+          </TabsTab>
         </TabsList>
         <TabsPanel value="edit">
           <Suspense fallback={<Fallback />}>
-            <LazyEditor isDisabled={disabled} onChange={setCodePolicy} value={codePolicy} />
+            <LazyEditor
+              highlight={highlight}
+              // Identifies the jump itself: it changes when you ask for a
+              // different rule or token, and not when you edit the buffer.
+              highlightKey={`${ruleRaw ?? ""}:${tokenParam ?? ""}`}
+              isDisabled={disabled}
+              onChange={setCodePolicy}
+              value={codePolicy}
+            />
           </Suspense>
         </TabsPanel>
         <TabsPanel value="diff">
@@ -126,30 +257,73 @@ export default function Page({ loaderData: { access, writable, policy } }: Route
             </p>
           </div>
         </TabsPanel>
+        <TabsPanel value="map">
+          {/*
+            The map is a read-only view built on a lot of assumptions about
+            policy shape, and it has only been exercised against a handful of
+            real ones. If it fails it must fail alone: the editor on the other
+            tab may be holding unsaved changes, and the route-level
+            ErrorBoundary would replace the entire page.
+          */}
+          <RenderErrorBoundary
+            fallback={
+              <div className="flex flex-col items-center gap-2.5 py-8">
+                <CircleX />
+                <p className="text-lg font-semibold">Failed to render the reachability map.</p>
+                <p className="max-w-prose text-center text-sm text-mist-500">
+                  Your policy is untouched and still editable on the other tabs. If this keeps
+                  happening, the policy shape is worth reporting.
+                </p>
+              </div>
+            }
+          >
+            <Suspense fallback={<Fallback />}>
+              {/*
+                Fed the SAVED policy, not the editor buffer: this map describes
+                what Headscale is actually enforcing right now. `unsaved` lets
+                it say so when the buffer has diverged, rather than quietly
+                showing something other than your draft.
+              */}
+              <LazyMap nodes={nodes} policy={policy} unsaved={codePolicy !== policy} />
+            </Suspense>
+          </RenderErrorBoundary>
+        </TabsPanel>
       </Tabs>
-      <Button
-        className="mr-2"
-        disabled={
-          disabled || fetcher.state !== "idle" || codePolicy.length === 0 || codePolicy === policy
-        }
-        onClick={() => {
-          const formData = new FormData();
-          formData.append("policy", codePolicy);
-          fetcher.submit(formData, { method: "PATCH" });
-        }}
-        variant="heavy"
-      >
-        Save
-      </Button>
-      <Button
-        disabled={disabled || fetcher.state !== "idle" || codePolicy === policy}
-        onClick={() => {
-          // Reset the editor to the original policy
-          setCodePolicy(policy);
-        }}
-      >
-        Discard Changes
-      </Button>
+      {/*
+        Editing controls, so they only belong to the editing tabs. The map is a
+        read-only view of the same buffer — showing Save under it implies the
+        map is something you are composing.
+      */}
+      {tab === "map" ? undefined : (
+        <>
+          <Button
+            className="mr-2"
+            disabled={
+              disabled ||
+              fetcher.state !== "idle" ||
+              codePolicy.length === 0 ||
+              codePolicy === policy
+            }
+            onClick={() => {
+              const formData = new FormData();
+              formData.append("policy", codePolicy);
+              fetcher.submit(formData, { method: "PATCH" });
+            }}
+            variant="heavy"
+          >
+            Save
+          </Button>
+          <Button
+            disabled={disabled || fetcher.state !== "idle" || codePolicy === policy}
+            onClick={() => {
+              // Reset the editor to the original policy
+              setCodePolicy(policy);
+            }}
+          >
+            Discard Changes
+          </Button>
+        </>
+      )}
     </div>
   );
 }

--- a/app/utils/acl/evaluate.ts
+++ b/app/utils/acl/evaluate.ts
@@ -1,0 +1,146 @@
+// Top-level orchestration: policy text + nodes -> directional reachability.
+
+import {
+  type AclEdge,
+  type AclEvaluation,
+  type AclNode,
+  type AclWarning,
+  type EdgeRule,
+  INTERNET,
+  type NodeId,
+  type SubnetInfo,
+} from "./model";
+import { parsePolicy } from "./parse";
+import { buildContext, cidrCovers, type EvalContext, expandAlias } from "./resolve";
+
+/**
+ * A wildcard rule on a large tailnet is quadratic: 500 nodes and one `*:*`
+ * rule is 249,500 edges, which no browser will draw. Stop and say so rather
+ * than locking up the tab on somebody else's policy.
+ */
+const MAX_EDGES = 20_000;
+
+export function evaluatePolicy(policyText: string, nodes: AclNode[]): AclEvaluation {
+  const { policy, warnings } = parsePolicy(policyText);
+  const ctx = buildContext(policy, nodes);
+  ctx.warnings.push(...warnings);
+
+  const edgeMap = new Map<string, AclEdge>();
+  let truncated = false;
+
+  for (const rule of policy.acls) {
+    // Alias resolution reports problems against whichever rule is current, so
+    // a warning can be traced back to the line that caused it.
+    ctx.ruleIndex = rule.index;
+    // src cannot contain autogroup:self/internet — expanded once.
+    const srcIds = new Set<NodeId>();
+    for (const alias of rule.src)
+      for (const id of expandAlias(alias, ctx, { side: "src" })) srcIds.add(id);
+
+    for (const srcId of srcIds) {
+      const srcNode = ctx.byId.get(srcId)!;
+      // dst expanded PER src, because autogroup:self couples the two.
+      for (const dst of rule.dst) {
+        const dstIds = expandAlias(dst.alias, ctx, { side: "dst", counterpart: srcNode });
+        for (const dstId of dstIds) {
+          if (dstId === srcId) continue; // no self-loops (INTERNET never equals a src)
+          if (edgeMap.size >= MAX_EDGES && !edgeMap.has(`${srcId} ${dstId}`)) {
+            truncated = true;
+            continue;
+          }
+          addEdge(edgeMap, srcId, dstId, {
+            ruleIndex: rule.index,
+            proto: rule.proto,
+            ports: dst.ports,
+            dstAlias: dst.alias,
+          });
+        }
+      }
+    }
+  }
+
+  if (truncated) {
+    ctx.ruleIndex = undefined;
+    ctx.warnings.push({
+      message: `This policy produces more than ${MAX_EDGES.toLocaleString()} flows; the map shows the first ${MAX_EDGES.toLocaleString()} only. Narrow a wildcard rule to see the rest.`,
+    });
+  }
+
+  const edges = [...edgeMap.values()];
+  // staticExpansions can discover further subnets, so collect them after it.
+  const expansions = staticExpansions(ctx);
+  return {
+    edges,
+    rules: policy.acls,
+    subnets: subnetInfos(ctx),
+    reachOut: adjacency(edges, (e) => [e.src, e.dst]),
+    reachIn: adjacency(edges, (e) => [e.dst, e.src]),
+    expansions,
+    warnings: dedupeWarnings(ctx.warnings),
+  };
+}
+
+/** The same alias is re-expanded once per src, so warnings repeat verbatim. */
+function dedupeWarnings(warnings: AclWarning[]): AclWarning[] {
+  const seen = new Map<string, AclWarning>();
+  for (const warning of warnings) {
+    const key = `${warning.ruleIndex ?? "-"}:${warning.message}`;
+    if (!seen.has(key)) seen.set(key, warning);
+  }
+  return [...seen.values()];
+}
+
+/** Attach each off-mesh subnet to the nodes advertising a route that covers it. */
+function subnetInfos(ctx: EvalContext): SubnetInfo[] {
+  return [...ctx.subnets].map(([id, cidr]) => ({
+    id,
+    cidr,
+    routers: ctx.nodes.filter((n) => n.routes.some((r) => cidrCovers(r, cidr))).map((n) => n.id),
+  }));
+}
+
+function addEdge(map: Map<string, AclEdge>, src: NodeId, dst: NodeId, rule: EdgeRule): void {
+  const key = `${src} ${dst}`;
+  const existing = map.get(key);
+  if (existing) existing.rules.push(rule);
+  else map.set(key, { src, dst, rules: [rule] });
+}
+
+function adjacency(
+  edges: AclEdge[],
+  pick: (e: AclEdge) => [NodeId, NodeId],
+): Map<NodeId, NodeId[]> {
+  const map = new Map<NodeId, Set<NodeId>>();
+  for (const e of edges) {
+    const [from, to] = pick(e);
+    const set = map.get(from) ?? new Set<NodeId>();
+    set.add(to);
+    map.set(from, set);
+  }
+  return new Map([...map].map(([k, v]) => [k, [...v]]));
+}
+
+// Context-free alias expansions for UI tooltips. autogroup:self is omitted by
+// construction (it needs a counterpart, so it has no static answer).
+function staticExpansions(ctx: EvalContext): Map<string, NodeId[]> {
+  const out = new Map<string, NodeId[]>();
+  // The side must match how the alias is actually used: expanding a src-only
+  // CIDR as a dst would mint a subnet pseudo-node that no rule points at.
+  const record = (alias: string, side: "src" | "dst") => {
+    if (out.has(alias)) return;
+    out.set(alias, [...expandAlias(alias, ctx, { side })]);
+  };
+  for (const rule of ctx.policy.acls) {
+    ctx.ruleIndex = rule.index;
+    for (const a of rule.src) if (!isRelational(a)) record(a, "src");
+    for (const d of rule.dst) if (!isRelational(d.alias)) record(d.alias, "dst");
+  }
+  ctx.ruleIndex = undefined;
+  return out;
+}
+
+function isRelational(alias: string): boolean {
+  return alias === "autogroup:self";
+}
+
+export { INTERNET };

--- a/app/utils/acl/locate.ts
+++ b/app/utils/acl/locate.ts
@@ -1,0 +1,165 @@
+// Source positions for ACL rules, so the UI can jump from a rule back to the
+// text that declares it.
+//
+// The parser throws positions away (it strips HuJSON, then JSON.parses), so
+// this walks the RAW text instead. It must therefore understand strings and
+// comments itself — a "}" inside a string or a "," inside a comment would
+// otherwise end an element early.
+
+export interface RuleRange {
+  /** Matches AclRule.index — position in the source array, skipped rules included. */
+  index: number;
+  /** Offsets into the original text, suitable for a CodeMirror selection. */
+  start: number;
+  end: number;
+}
+
+/**
+ * Offsets of every element of the top-level `acls` array. Returns an empty
+ * array when the policy has no `acls`, or is too malformed to scan.
+ */
+/** Sentinel depths for the one `acls` array: not reached yet, and finished. */
+const ACLS_UNSEEN = -1;
+const ACLS_CLOSED = -2;
+
+export function locateRules(policyText: string): RuleRange[] {
+  const ranges: RuleRange[] = [];
+  const length = policyText.length;
+
+  let i = 0;
+  let depth = 0;
+  let aclsDepth = ACLS_UNSEEN;
+  let elementStart = -1;
+  let lastKey: string | null = null;
+  let stringStart = -1;
+
+  while (i < length) {
+    const char = policyText[i];
+    const next = policyText[i + 1];
+
+    // --- comments ---------------------------------------------------------
+    if (char === "/" && next === "/") {
+      while (i < length && policyText[i] !== "\n") i++;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      i += 2;
+      while (i < length && !(policyText[i] === "*" && policyText[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+
+    // --- strings ----------------------------------------------------------
+    if (char === '"') {
+      // A string can itself be the start of an element (a bare dst, say), so
+      // record the element before consuming it.
+      if (isElementStart(aclsDepth, depth, elementStart)) elementStart = i;
+      stringStart = i;
+      i++;
+      let escaped = false;
+      while (i < length) {
+        const c = policyText[i];
+        if (escaped) escaped = false;
+        else if (c === "\\") escaped = true;
+        else if (c === '"') break;
+        i++;
+      }
+      lastKey = policyText.slice(stringStart + 1, i);
+      i++;
+      continue;
+    }
+
+    // An element begins at the first meaningful character after "[" or ",".
+    // A closing bracket is not a start — without this the "]" after a trailing
+    // comma would open a zero-length element.
+    if (
+      isElementStart(aclsDepth, depth, elementStart) &&
+      !isSpace(char) &&
+      char !== "," &&
+      char !== "]" &&
+      char !== "}"
+    ) {
+      elementStart = i;
+    }
+
+    // --- containers -------------------------------------------------------
+    if (char === "{" || char === "[") {
+      // `acls` sits at the top level, so the array opens at depth 1. Guarding
+      // on that avoids matching an "acls" key nested inside something else.
+      if (aclsDepth === ACLS_UNSEEN && char === "[" && lastKey === "acls" && depth === 1) {
+        aclsDepth = depth + 1;
+        elementStart = -1;
+      }
+      depth++;
+      i++;
+      continue;
+    }
+
+    if (char === "}" || char === "]") {
+      if (char === "]" && depth === aclsDepth) {
+        pushRange(ranges, policyText, elementStart, i);
+        elementStart = -1;
+        aclsDepth = ACLS_CLOSED;
+      }
+      depth--;
+      i++;
+      continue;
+    }
+
+    if (char === "," && depth === aclsDepth) {
+      pushRange(ranges, policyText, elementStart, i);
+      elementStart = -1;
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return ranges;
+}
+
+/**
+ * Narrow a rule's range down to one token inside it — the alias a warning is
+ * actually about, rather than the whole block around it.
+ *
+ * The quoted form is tried first so that a token like `bob` cannot match
+ * inside `bobcat`. The bare form is the fallback, because a dst alias such as
+ * `tag:web` is written `"tag:web:80"` in the source and never appears quoted
+ * on its own. Returns null when the token cannot be found, so callers can fall
+ * back to highlighting the rule.
+ */
+export function locateRuleToken(
+  policyText: string,
+  rule: RuleRange,
+  token: string,
+): RuleRange | null {
+  if (token.length === 0) return null;
+  const haystack = policyText.slice(rule.start, rule.end);
+
+  const quoted = haystack.indexOf(`"${token}"`);
+  if (quoted !== -1) {
+    const start = rule.start + quoted + 1; // skip the opening quote
+    return { index: rule.index, start, end: start + token.length };
+  }
+
+  const bare = haystack.indexOf(token);
+  if (bare === -1) return null;
+  return { index: rule.index, start: rule.start + bare, end: rule.start + bare + token.length };
+}
+
+function isElementStart(aclsDepth: number, depth: number, elementStart: number): boolean {
+  return aclsDepth > 0 && depth === aclsDepth && elementStart === -1;
+}
+
+function isSpace(char: string): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r";
+}
+
+function pushRange(ranges: RuleRange[], text: string, start: number, stop: number): void {
+  if (start === -1) return; // empty slot, e.g. the gap left by a trailing comma
+  let end = stop;
+  while (end > start && isSpace(text[end - 1])) end--;
+  if (end <= start) return;
+  ranges.push({ index: ranges.length, start, end });
+}

--- a/app/utils/acl/model.ts
+++ b/app/utils/acl/model.ts
@@ -1,0 +1,145 @@
+// ACL evaluator — core type model.
+//
+// This module has NO dependency on server code or React. Everything here is a
+// plain data shape so the evaluator can run in a loader (Node) or the browser
+// (interactive re-eval), and be unit-tested in isolation.
+//
+// Terminology mirrors Headscale policy v2 (HuJSON):
+//   groups     -> named sets of user identities        ("group:eng": ["alice@"])
+//   tagOwners  -> who may assign a tag (NOT used for reachability, kept for UI)
+//   hosts      -> named CIDR/IP aliases                ("server": "100.64.0.1/32")
+//   acls[]     -> directional accept rules (src -> dst:ports over proto)
+
+export type NodeId = string;
+
+/** A single node reduced to only what ACL resolution needs. */
+export interface AclNode {
+  id: NodeId;
+  name: string; // givenName || name, for labels
+  ips: string[]; // ipAddresses, used for CIDR/host-alias matching
+  user?: string; // User.name, normalized WITHOUT trailing "@" (see to-node.ts)
+  tags: string[]; // e.g. ["tag:web"]; forced tags + advertised, as Headscale reports
+  routes: string[]; // approvedRoutes — needed for autogroup:internet / subnet dsts
+  hasExitNode: boolean; // approved 0.0.0.0/0 or ::/0
+}
+
+/** A parsed port range. `*` becomes { start: 0, end: 65535 }. */
+export interface PortRange {
+  start: number;
+  end: number;
+}
+
+export type Protocol = "tcp" | "udp" | "icmp" | "sctp" | string;
+
+/** One dst token split into its alias and its port spec. */
+export interface DstEntry {
+  alias: string; // "tag:web"        (everything before the final ":")
+  ports: PortRange[]; // parsed from ":22,80-90" or ":*"
+  raw: string; // original token, for display / debugging
+}
+
+export interface AclRule {
+  index: number; // position in acls[]; the back-reference an edge carries
+  action: "accept"; // Headscale v2 only supports accept in acls[]
+  src: string[]; // raw src aliases (unexpanded)
+  dst: DstEntry[];
+  proto?: Protocol; // undefined = all protocols
+}
+
+export interface AclPolicy {
+  groups: Record<string, string[]>;
+  tagOwners: Record<string, string[]>;
+  hosts: Record<string, string>;
+  acls: AclRule[];
+}
+
+// --- Evaluation output -----------------------------------------------------
+
+/** Why a given (src -> dst) edge exists: which rule + what it permits. */
+export interface EdgeRule {
+  ruleIndex: number;
+  proto?: Protocol;
+  ports: PortRange[];
+  /**
+   * The dst token that actually matched, as written in the policy. A rule can
+   * declare many destinations; without this the UI can only show all of them,
+   * most of which may have nothing to do with this pair.
+   */
+  dstAlias: string;
+}
+
+/** Sentinel dst for `autogroup:internet` — not a peer, the exit-node world. */
+export const INTERNET: NodeId = "__internet__";
+
+/**
+ * Prefix for off-mesh subnet pseudo-nodes. A dst CIDR matching no tailnet node
+ * is usually not a mistake — it is a LAN reachable through a subnet router — so
+ * it becomes its own node rather than vanishing from the map.
+ *
+ * One pseudo-node PER DISTINCT CIDR, unlike the single INTERNET hub: subnets
+ * are not interchangeable, and collapsing them would hide the routing story.
+ */
+const SUBNET_PREFIX = "__subnet__:";
+
+export function subnetNodeId(cidr: string): NodeId {
+  return `${SUBNET_PREFIX}${cidr}`;
+}
+
+export function isSubnetNodeId(id: NodeId): boolean {
+  return id.startsWith(SUBNET_PREFIX);
+}
+
+/** The CIDR behind a subnet pseudo-node id, or null if `id` is not one. */
+export function subnetCidrOf(id: NodeId): string | null {
+  return isSubnetNodeId(id) ? id.slice(SUBNET_PREFIX.length) : null;
+}
+
+/** An off-mesh subnet reached as a dst, plus who advertises a route to it. */
+export interface SubnetInfo {
+  id: NodeId;
+  cidr: string;
+  /** Nodes whose approved routes cover this CIDR. Empty = nothing routes it. */
+  routers: NodeId[];
+}
+
+export interface AclEdge {
+  src: NodeId;
+  dst: NodeId; // a real node id, INTERNET, or a subnet pseudo-node
+  rules: EdgeRule[]; // one entry per rule/dst-port-spec that allows this pair
+}
+
+/**
+ * A problem found while evaluating. Carries the rule it came from where that
+ * is knowable, so the UI can offer to jump to it — a warning you cannot locate
+ * is much less useful than one you can.
+ */
+export interface AclWarning {
+  message: string;
+  ruleIndex?: number;
+  /**
+   * The offending text as it appears in the policy, so the UI can highlight
+   * the token itself rather than the whole rule around it.
+   */
+  token?: string;
+}
+
+export interface AclEvaluation {
+  edges: AclEdge[];
+  /**
+   * The parsed rules, so the UI can show rule text next to an edge or node.
+   * Indexed by position in the source policy — skipped (non-accept) rules are
+   * absent, so look rules up by `.index`, not by array position.
+   */
+  rules: AclRule[];
+  /** Off-mesh subnets that appeared as a dst; the map draws these as nodes. */
+  subnets: SubnetInfo[];
+  reachOut: Map<NodeId, NodeId[]>; // src -> everything it can reach
+  reachIn: Map<NodeId, NodeId[]>; // dst -> everything that can reach it
+  /**
+   * alias -> node ids, for UI tooltips. Only STATIC aliases are listed here.
+   * autogroup:self is deliberately absent: it couples src and dst, so it has
+   * no context-free expansion (see resolve.ts).
+   */
+  expansions: Map<string, NodeId[]>;
+  warnings: AclWarning[]; // unresolved aliases, wildcard blow-ups, etc.
+}

--- a/app/utils/acl/parse.ts
+++ b/app/utils/acl/parse.ts
@@ -1,0 +1,114 @@
+// HuJSON policy text -> typed AclPolicy.
+
+import { stripHuJSON } from "~/utils/hujson";
+
+import type { AclPolicy, AclRule, AclWarning, DstEntry, PortRange } from "./model";
+
+export interface ParseResult {
+  policy: AclPolicy;
+  warnings: AclWarning[];
+}
+
+const FULL_RANGE: PortRange = { start: 0, end: 65535 };
+const PORT_SPEC = /^(\d+)(-(\d+))?(,(\d+)(-(\d+))?)*$/;
+
+export function parsePolicy(policyText: string): ParseResult {
+  const warnings: AclWarning[] = [];
+  let raw: unknown;
+  try {
+    raw = JSON.parse(stripHuJSON(policyText));
+  } catch (e) {
+    return {
+      policy: { groups: {}, tagOwners: {}, hosts: {}, acls: [] },
+      warnings: [{ message: `Failed to parse policy: ${(e as Error).message}` }],
+    };
+  }
+
+  const root = isRecord(raw) ? raw : {};
+  const acls: AclRule[] = [];
+  const rawAcls = Array.isArray(root.acls) ? root.acls : [];
+
+  rawAcls.forEach((r, index) => {
+    if (!isRecord(r)) {
+      warnings.push({ message: `acls[${index}] is not an object; skipped`, ruleIndex: index });
+      return;
+    }
+    if (r.action !== "accept") {
+      warnings.push({
+        message: `acls[${index}] action "${String(r.action)}" is not "accept"; skipped`,
+        ruleIndex: index,
+      });
+      return;
+    }
+    const src = Array.isArray(r.src) ? r.src.map(String) : [];
+    const dst = (Array.isArray(r.dst) ? r.dst.map(String) : []).map((d) =>
+      parseDst(d, warnings, index),
+    );
+    acls.push({
+      index,
+      action: "accept",
+      src,
+      dst,
+      proto: typeof r.proto === "string" ? r.proto : undefined,
+    });
+  });
+
+  return {
+    policy: {
+      groups: asStringArrayRecord(root.groups),
+      tagOwners: asStringArrayRecord(root.tagOwners),
+      hosts: asStringRecord(root.hosts),
+      acls,
+    },
+    warnings,
+  };
+}
+
+/**
+ * Split one dst token into alias + ports. Splits on the LAST ":" whose suffix
+ * is a valid port spec — aliases (tag:/group:/autogroup:) and IPv6 CIDRs are
+ * full of colons, so first-colon splitting would corrupt them.
+ */
+export function parseDst(raw: string, warnings?: AclWarning[], ruleIndex?: number): DstEntry {
+  const idx = raw.lastIndexOf(":");
+  const spec = idx === -1 ? "" : raw.slice(idx + 1);
+  if (idx === -1 || !isPortSpec(spec)) {
+    warnings?.push({
+      message: `dst "${raw}"${ruleIndex != null ? ` in acls[${ruleIndex}]` : ""} has no valid port spec; defaulting to *`,
+      ruleIndex,
+      token: raw,
+    });
+    return { alias: raw, ports: [FULL_RANGE], raw };
+  }
+  return { alias: raw.slice(0, idx), ports: parsePorts(spec), raw };
+}
+
+export function parsePorts(spec: string): PortRange[] {
+  if (spec === "*") return [FULL_RANGE];
+  return spec.split(",").map((part) => {
+    const [a, b] = part.split("-");
+    const start = Number(a);
+    return { start, end: b !== undefined ? Number(b) : start };
+  });
+}
+
+function isPortSpec(spec: string): boolean {
+  return spec === "*" || PORT_SPEC.test(spec);
+}
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === "object" && !Array.isArray(v);
+}
+
+function asStringRecord(v: unknown): Record<string, string> {
+  if (!isRecord(v)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, val] of Object.entries(v)) if (typeof val === "string") out[k] = val;
+  return out;
+}
+
+function asStringArrayRecord(v: unknown): Record<string, string[]> {
+  if (!isRecord(v)) return {};
+  const out: Record<string, string[]> = {};
+  for (const [k, val] of Object.entries(v)) if (Array.isArray(val)) out[k] = val.map(String);
+  return out;
+}

--- a/app/utils/acl/ports.ts
+++ b/app/utils/acl/ports.ts
@@ -1,0 +1,65 @@
+// Port display helpers. Pure, and outside the component so the panel and its
+// tests agree on what a port list looks like.
+
+import type { PortRange } from "./model";
+
+const ALL_PORTS: PortRange = { start: 0, end: 65535 };
+
+/**
+ * Sort and fuse ranges that overlap or touch: a policy written as
+ * `2456,2457,2458` parses to three one-wide ranges and should read as
+ * `2456-2458`. Real policies are full of these runs.
+ */
+export function mergePortRanges(ports: PortRange[]): PortRange[] {
+  if (ports.length === 0) return [];
+
+  const sorted = [...ports].sort((a, b) => a.start - b.start || a.end - b.end);
+  const merged: PortRange[] = [{ ...sorted[0] }];
+
+  for (const range of sorted.slice(1)) {
+    const last = merged[merged.length - 1];
+    // `end + 1` fuses adjacent ranges, not just overlapping ones.
+    if (range.start <= last.end + 1) last.end = Math.max(last.end, range.end);
+    else merged.push({ ...range });
+  }
+
+  return merged;
+}
+
+export function isAllPorts(ports: PortRange[]): boolean {
+  const merged = mergePortRanges(ports);
+  return (
+    merged.length === 1 && merged[0].start === ALL_PORTS.start && merged[0].end === ALL_PORTS.end
+  );
+}
+
+/** One display token per merged range. */
+export function portTokens(ports: PortRange[]): string[] {
+  if (isAllPorts(ports)) return ["*"];
+  return mergePortRanges(ports).map((range) =>
+    range.start === range.end ? String(range.start) : `${range.start}-${range.end}`,
+  );
+}
+
+export function formatPorts(ports: PortRange[]): string {
+  return portTokens(ports).join(", ");
+}
+
+/** How many individual ports the ranges cover. */
+export function countPorts(ports: PortRange[]): number {
+  return mergePortRanges(ports).reduce((total, range) => total + (range.end - range.start + 1), 0);
+}
+
+/**
+ * Short enough for a card header: the values themselves when there are only a
+ * few, a count when there are many. A long list was previously truncated with
+ * no way to reveal the rest, which is worse than not showing it.
+ */
+export function summarisePorts(ports: PortRange[]): string {
+  if (isAllPorts(ports)) return "all ports";
+
+  const tokens = portTokens(ports);
+  if (tokens.length === 0) return "no ports";
+  if (tokens.length <= 3) return tokens.join(", ");
+  return `${countPorts(ports)} ports`;
+}

--- a/app/utils/acl/resolve.ts
+++ b/app/utils/acl/resolve.ts
@@ -1,0 +1,272 @@
+// Alias resolution: turn a policy token into the set of nodes it matches.
+// See the token catalogue in the header comment of the previous revision.
+
+import {
+  type AclNode,
+  type AclPolicy,
+  type AclWarning,
+  INTERNET,
+  type NodeId,
+  subnetNodeId,
+} from "./model";
+
+interface Cidr {
+  // IPv4 only for now (this fork's policies are v4). v6 tokens fall back to
+  // exact-string match against node ips; see matchIp.
+  net: number;
+  mask: number;
+}
+
+interface IndexedNode {
+  node: AclNode;
+  v4: number[]; // parsed IPv4 addresses
+  v6: string[]; // raw IPv6 strings, for exact-match fallback
+}
+
+export interface EvalContext {
+  policy: AclPolicy;
+  nodes: AclNode[];
+  byId: Map<NodeId, AclNode>;
+  byUser: Map<string, NodeId[]>;
+  byTag: Map<string, NodeId[]>;
+  indexed: IndexedNode[];
+  /** Off-mesh subnet pseudo-nodes discovered during expansion: id -> cidr. */
+  subnets: Map<NodeId, string>;
+  warnings: AclWarning[];
+  /**
+   * The rule being expanded, set by evaluate.ts as it walks acls[]. Alias
+   * resolution has no rule context of its own, but a warning without one
+   * cannot be located in the policy.
+   */
+  ruleIndex?: number;
+}
+
+/**
+ * Record a problem against whichever rule is currently being expanded, and
+ * against the specific token at fault where there is one.
+ */
+function warn(ctx: EvalContext, message: string, token?: string): void {
+  ctx.warnings.push({ message, ruleIndex: ctx.ruleIndex, token });
+}
+
+export function buildContext(policy: AclPolicy, nodes: AclNode[]): EvalContext {
+  const byId = new Map<NodeId, AclNode>();
+  const byUser = new Map<string, NodeId[]>();
+  const byTag = new Map<string, NodeId[]>();
+  const indexed: IndexedNode[] = [];
+
+  for (const node of nodes) {
+    byId.set(node.id, node);
+    if (node.user) push(byUser, normalizeUser(node.user), node.id);
+    for (const tag of node.tags) push(byTag, tag, node.id);
+
+    const v4: number[] = [];
+    const v6: string[] = [];
+    for (const ip of node.ips) {
+      const n = v4ToInt(ip);
+      if (n != null) v4.push(n);
+      else v6.push(ip);
+    }
+    indexed.push({ node, v4, v6 });
+  }
+
+  return { policy, nodes, byId, byUser, byTag, indexed, subnets: new Map(), warnings: [] };
+}
+
+export interface ExpandOptions {
+  side: "src" | "dst";
+  counterpart?: AclNode; // required only for autogroup:self
+}
+
+export function expandAlias(alias: string, ctx: EvalContext, opts: ExpandOptions): Set<NodeId> {
+  const out = new Set<NodeId>();
+
+  if (alias === "*") {
+    for (const n of ctx.nodes) out.add(n.id);
+    return out;
+  }
+
+  if (alias.startsWith("tag:")) {
+    for (const id of ctx.byTag.get(alias) ?? []) out.add(id);
+    return out;
+  }
+
+  if (alias.startsWith("group:")) {
+    for (const id of expandGroup(alias, ctx, new Set())) out.add(id);
+    return out;
+  }
+
+  if (alias.startsWith("autogroup:")) {
+    return expandAutogroup(alias, ctx, opts);
+  }
+
+  // Host alias -> its CIDR, then IP match.
+  const hostCidr = ctx.policy.hosts[alias];
+  if (hostCidr != null) {
+    matchCidrOrSubnet(out, hostCidr, ctx, opts, alias);
+    return out;
+  }
+
+  // Raw CIDR or IP.
+  if (looksLikeIp(alias)) {
+    matchCidrOrSubnet(out, alias, ctx, opts, alias);
+    return out;
+  }
+
+  // Otherwise a bare user identity.
+  const ids = ctx.byUser.get(normalizeUser(alias));
+  if (ids) for (const id of ids) out.add(id);
+  else warn(ctx, `Unresolved alias "${alias}" (no matching user, tag, host, or IP)`, alias);
+  return out;
+}
+
+function expandAutogroup(alias: string, ctx: EvalContext, opts: ExpandOptions): Set<NodeId> {
+  const out = new Set<NodeId>();
+  switch (alias) {
+    case "autogroup:internet":
+      if (opts.side === "dst") out.add(INTERNET);
+      else warn(ctx, `autogroup:internet is not valid as a src`, "autogroup:internet");
+      return out;
+    case "autogroup:member":
+      for (const n of ctx.nodes) if (n.user && n.tags.length === 0) out.add(n.id);
+      return out;
+    case "autogroup:tagged":
+      for (const n of ctx.nodes) if (n.tags.length > 0) out.add(n.id);
+      return out;
+    case "autogroup:self": {
+      if (opts.side !== "dst" || !opts.counterpart?.user) {
+        warn(ctx, `autogroup:self needs a dst context with a user-owned src`, "autogroup:self");
+        return out;
+      }
+      const owner = normalizeUser(opts.counterpart.user);
+      for (const n of ctx.nodes)
+        if (n.user && normalizeUser(n.user) === owner && n.tags.length === 0) out.add(n.id);
+      return out;
+    }
+    default:
+      warn(ctx, `Unknown autogroup "${alias}"`, alias);
+      return out;
+  }
+}
+
+function expandGroup(group: string, ctx: EvalContext, seen: Set<string>): Set<NodeId> {
+  const out = new Set<NodeId>();
+  if (seen.has(group)) return out; // cycle guard
+  seen.add(group);
+  const members = ctx.policy.groups[group];
+  if (!members) {
+    warn(ctx, `Undefined group "${group}"`, group);
+    return out;
+  }
+  for (const member of members) {
+    if (member.startsWith("group:")) for (const id of expandGroup(member, ctx, seen)) out.add(id);
+    else if (member.startsWith("tag:")) for (const id of ctx.byTag.get(member) ?? []) out.add(id);
+    else for (const id of ctx.byUser.get(normalizeUser(member)) ?? []) out.add(id);
+  }
+  return out;
+}
+
+// --- IP / CIDR helpers (IPv4) ----------------------------------------------
+
+/**
+ * Match a CIDR against the tailnet. If nothing matches, the range is off-mesh:
+ * as a dst it becomes a subnet pseudo-node so the map can draw it, as a src it
+ * is only reported — a subnet has no node for an edge to originate from.
+ */
+function matchCidrOrSubnet(
+  out: Set<NodeId>,
+  cidr: string,
+  ctx: EvalContext,
+  opts: ExpandOptions,
+  label: string,
+): void {
+  if (matchCidrInto(out, cidr, ctx)) return;
+
+  if (opts.side === "dst") {
+    const id = subnetNodeId(cidr);
+    ctx.subnets.set(id, cidr);
+    out.add(id);
+    return;
+  }
+
+  warn(
+    ctx,
+    `"${label}" matches no node; an off-mesh range as src cannot be drawn (only dst ranges become subnets)`,
+    label,
+  );
+}
+
+/** Returns true if the token matched at least one node. */
+function matchCidrInto(out: Set<NodeId>, token: string, ctx: EvalContext): boolean {
+  let matched = false;
+  const cidr = parseCidr(token);
+  if (!cidr) {
+    // Not v4 — fall back to exact string match (covers v6 tokens).
+    for (const ix of ctx.indexed)
+      if (ix.v6.includes(token)) {
+        out.add(ix.node.id);
+        matched = true;
+      }
+    return matched;
+  }
+  for (const ix of ctx.indexed)
+    for (const ip of ix.v4)
+      if ((ip & cidr.mask) === (cidr.net & cidr.mask)) {
+        out.add(ix.node.id);
+        matched = true;
+        break;
+      }
+  return matched;
+}
+
+/**
+ * True if CIDR `outer` fully contains `inner` — used to find which node's
+ * approved routes serve a subnet. Masks are contiguous, so a numerically
+ * smaller mask is the broader prefix.
+ */
+export function cidrCovers(outer: string, inner: string): boolean {
+  if (outer === inner) return true;
+  const o = parseCidr(outer);
+  const i = parseCidr(inner);
+  if (!o || !i) return false;
+  if (o.mask > i.mask) return false; // outer is narrower than inner
+  return (i.net & o.mask) === (o.net & o.mask);
+}
+
+function parseCidr(token: string): Cidr | null {
+  const [addr, bitsRaw] = token.split("/");
+  const net = v4ToInt(addr);
+  if (net == null) return null;
+  const bits = bitsRaw === undefined ? 32 : Number(bitsRaw);
+  if (!Number.isInteger(bits) || bits < 0 || bits > 32) return null;
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return { net, mask };
+}
+
+function v4ToInt(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    const x = Number(p);
+    if (!Number.isInteger(x) || x < 0 || x > 255 || (p.length > 1 && p[0] === "0")) return null;
+    n = (n << 8) | x;
+  }
+  return n >>> 0;
+}
+
+function looksLikeIp(token: string): boolean {
+  return token.includes("/") || token.includes(":") || /^\d+\.\d+\.\d+\.\d+$/.test(token);
+}
+
+function normalizeUser(u: string): string {
+  return u.endsWith("@") ? u.slice(0, -1) : u;
+}
+
+function push(map: Map<string, NodeId[]>, key: string, id: NodeId): void {
+  const arr = map.get(key);
+  if (arr) arr.push(id);
+  else map.set(key, [id]);
+}
+
+export { INTERNET };

--- a/app/utils/acl/to-node.ts
+++ b/app/utils/acl/to-node.ts
@@ -1,0 +1,21 @@
+// Adapter: PopulatedNode (headplane's node shape) -> AclNode (evaluator input).
+//
+// Kept separate so the evaluator never imports app types. Headscale keys ACL
+// `src`/dst user tokens on the plain user name (it appends "@" itself when it
+// canonicalizes identities), and tag-only nodes may have no user at all.
+
+import type { PopulatedNode } from "~/utils/node-info";
+
+import type { AclNode } from "./model";
+
+export function toAclNode(node: PopulatedNode): AclNode {
+  return {
+    id: node.id,
+    name: node.givenName || node.name,
+    ips: node.ipAddresses,
+    user: node.user?.name, // may be undefined for tag-only nodes (HS 0.28+)
+    tags: node.tags,
+    routes: node.customRouting.subnetApprovedRoutes,
+    hasExitNode: node.customRouting.exitApproved,
+  };
+}

--- a/app/utils/hujson.ts
+++ b/app/utils/hujson.ts
@@ -1,0 +1,80 @@
+// Headscale and Tailscale policies are HuJSON: JSON plus comments and trailing
+// commas.
+//
+// node-info.ts has its own copy of this for the tag autocomplete. Merging the
+// two would mean editing a file the machines pages depend on for no reason
+// other than tidiness, so the duplication stays.
+
+/**
+ * Strip comments and trailing commas so `JSON.parse` will accept the text.
+ *
+ * String-aware, which is the whole reason this is a scanner rather than a pair
+ * of regexes: a policy is full of values like `"tag:web"` and `"10.0.0.0/8"`,
+ * and a naive strip would treat `//` inside a URL or a comma before a closing
+ * quote as syntax. Comments are removed rather than blanked, except for the
+ * newline that ends a line comment, which is kept so line structure survives.
+ */
+export function stripHuJSON(input: string): string {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    const next = input[i + 1];
+
+    if (inLineComment) {
+      if (char === "\n" || char === "\r") {
+        inLineComment = false;
+        output += char;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === "*" && next === "/") {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      output += char;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+
+    output += char;
+  }
+
+  // Safe only after the scan above has removed anything inside a string from
+  // consideration — by here every remaining comma is structural.
+  return output.replace(/,\s*([}\]])/g, "$1");
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -33,7 +33,7 @@ in
     inherit (finalAttrs) pname version src;
 		fetcherVersion = 3;
 		pnpm = pnpm_10;
-		hash = "sha256-2F7DplZ+PAMkDepsoeUxS04+IefWy3ARgE8G6Fz+YnQ=";
+		hash = "sha256-eLsIEeLFRB3ZbDm8hilrIVkCVcaPP6wJDxu3AAOpUSo=";
   };
 
     buildPhase = ''

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@lezer/highlight": "^1.2.3",
     "@react-router/node": "^8.0.1",
     "@uiw/react-codemirror": "4.25.10",
+    "@xyflow/react": "^12.11.3",
     "arktype": "^2.2.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "1.0.0-beta.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@uiw/react-codemirror':
         specifier: 4.25.10
         version: 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)(@lezer/common@1.5.2))(@codemirror/language@6.12.3)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.1)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@xyflow/react':
+        specifier: ^12.11.3
+        version: 12.11.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       arktype:
         specifier: ^2.2.1
         version: 2.2.1
@@ -1686,6 +1689,24 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2042,6 +2063,22 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
+  '@xyflow/react@12.11.3':
+    resolution: {integrity: sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.80':
+    resolution: {integrity: sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2305,6 +2342,9 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -2388,6 +2428,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -4078,6 +4156,21 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -5410,6 +5503,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/docker-modem@3.0.6':
@@ -5744,6 +5858,31 @@ snapshots:
     dependencies:
       vue: 3.5.18(typescript@7.0.1-rc)
 
+  '@xyflow/react@12.11.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@xyflow/system': 0.0.80
+      classcat: 5.0.5
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.80':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -5998,6 +6137,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  classcat@5.0.5: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -6088,6 +6229,42 @@ snapshots:
   csstype@3.1.3: {}
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-uri-to-buffer@4.0.1:
     optional: true
@@ -7837,5 +8014,12 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zustand@4.5.7(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   zwitch@2.0.4: {}

--- a/tests/unit/utils/acl.test.ts
+++ b/tests/unit/utils/acl.test.ts
@@ -1,0 +1,791 @@
+import { describe, expect, test } from "vitest";
+
+import { evaluatePolicy } from "~/utils/acl/evaluate";
+import { locateRules, locateRuleToken } from "~/utils/acl/locate";
+import {
+  type AclNode,
+  type AclWarning,
+  INTERNET,
+  isSubnetNodeId,
+  subnetCidrOf,
+  subnetNodeId,
+} from "~/utils/acl/model";
+import { parseDst, parsePolicy, parsePorts } from "~/utils/acl/parse";
+import {
+  countPorts,
+  formatPorts,
+  mergePortRanges,
+  portTokens,
+  summarisePorts,
+} from "~/utils/acl/ports";
+
+// Fixture tailnet. Deliberately synthetic rather than a copy of any real
+// policy: it covers the same shapes the hand-trace exercised (wildcard fan-out,
+// same-dst merge, bidirectional pairs, autogroup:internet, bare-IP == /32)
+// while staying readable and safe to commit.
+//
+// web/router are tag-only (no user) — Headscale 0.28+ allows this, and
+// to-node.ts maps it to `user: undefined`.
+function node(partial: Partial<AclNode> & { id: string }): AclNode {
+  return {
+    name: `node-${partial.id}`,
+    ips: [],
+    tags: [],
+    routes: [],
+    hasExitNode: false,
+    ...partial,
+  };
+}
+
+const ALICE_LAPTOP = node({ id: "1", user: "alice", ips: ["100.64.0.1"] });
+const ALICE_PHONE = node({ id: "2", user: "alice", ips: ["100.64.0.2"] });
+const BOB_LAPTOP = node({ id: "3", user: "bob", ips: ["100.64.0.3"] });
+const WEB = node({ id: "4", tags: ["tag:web"], ips: ["100.64.0.4"] });
+const ROUTER = node({
+  id: "5",
+  tags: ["tag:router"],
+  ips: ["100.64.0.5"],
+  routes: ["192.168.1.0/24"],
+  hasExitNode: true,
+});
+
+const NODES = [ALICE_LAPTOP, ALICE_PHONE, BOB_LAPTOP, WEB, ROUTER];
+
+/** Set of "src>dst" pairs, the shape most assertions care about. */
+function pairs(policy: string, nodes: AclNode[] = NODES): Set<string> {
+  return new Set(evaluatePolicy(policy, nodes).edges.map((e) => `${e.src}>${e.dst}`));
+}
+
+function policyOf(...acls: string[]): string {
+  return `{ "acls": [ ${acls.join(",")} ] }`;
+}
+
+describe("ACL evaluator", () => {
+  describe("parsing", () => {
+    test("strips HuJSON comments and trailing commas", () => {
+      const { policy, warnings } = parsePolicy(`{
+        // line comment
+        "groups": { "group:eng": ["alice"], },
+        /* block
+           comment */
+        "acls": [ { "action": "accept", "src": ["*"], "dst": ["*:22"] }, ],
+      }`);
+
+      expect(warnings).toEqual([]);
+      expect(policy.groups["group:eng"]).toEqual(["alice"]);
+      expect(policy.acls).toHaveLength(1);
+    });
+
+    test("a // sequence inside a string is not treated as a comment", () => {
+      const { policy } = parsePolicy(`{ "hosts": { "url": "https://example.com" } }`);
+      expect(policy.hosts.url).toBe("https://example.com");
+    });
+
+    test("malformed policy degrades to empty rather than throwing", () => {
+      const { policy, warnings } = parsePolicy("{ not json");
+      expect(policy.acls).toEqual([]);
+      expect(warnings[0].message).toMatch(/Failed to parse policy/);
+    });
+
+    test("non-accept rules are skipped with a warning", () => {
+      const { policy, warnings } = parsePolicy(
+        `{ "acls": [ { "action": "deny", "src": ["*"], "dst": ["*:*"] } ] }`,
+      );
+      expect(policy.acls).toEqual([]);
+      expect(warnings[0].message).toMatch(/is not "accept"/);
+    });
+
+    test("dst splits on the LAST colon that yields a valid port spec", () => {
+      expect(parseDst("tag:web:22").alias).toBe("tag:web");
+      expect(parseDst("autogroup:internet:*").alias).toBe("autogroup:internet");
+      // IPv6 is colon-dense; first-colon splitting would corrupt it.
+      expect(parseDst("fd7a:115c:a1e0::1:80").alias).toBe("fd7a:115c:a1e0::1");
+    });
+
+    test("a dst with no valid port spec defaults to all ports, with a warning", () => {
+      const warnings: AclWarning[] = [];
+      const dst = parseDst("tag:web", warnings, 3);
+      expect(dst.alias).toBe("tag:web");
+      expect(dst.ports).toEqual([{ start: 0, end: 65535 }]);
+      expect(warnings[0].message).toMatch(/acls\[3\]/);
+      expect(warnings[0].ruleIndex).toBe(3);
+    });
+
+    test("port specs cover wildcard, singles, lists and ranges", () => {
+      expect(parsePorts("*")).toEqual([{ start: 0, end: 65535 }]);
+      expect(parsePorts("22")).toEqual([{ start: 22, end: 22 }]);
+      expect(parsePorts("22,8000-8100")).toEqual([
+        { start: 22, end: 22 },
+        { start: 8000, end: 8100 },
+      ]);
+    });
+  });
+
+  describe("locating rules in the source text", () => {
+    /** The slice each range points at, for readable assertions. */
+    function slices(policy: string): string[] {
+      return locateRules(policy).map((r) => policy.slice(r.start, r.end));
+    }
+
+    test("returns one range per rule, pointing at the rule text", () => {
+      const policy = `{
+        "acls": [
+          { "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] },
+          { "action": "accept", "src": ["bob"], "dst": ["tag:web:443"] }
+        ]
+      }`;
+
+      expect(slices(policy)).toEqual([
+        `{ "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] }`,
+        `{ "action": "accept", "src": ["bob"], "dst": ["tag:web:443"] }`,
+      ]);
+    });
+
+    test("indexes line up with the rules the evaluator reports", () => {
+      // acls[1] is non-accept and skipped by the parser, but the surviving
+      // rule keeps index 2 — the UI looks rules up by index, so a mismatch
+      // here would highlight the wrong block.
+      const policy = `{
+        "acls": [
+          { "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] },
+          { "action": "deny", "src": ["bob"], "dst": ["tag:web:80"] },
+          { "action": "accept", "src": ["bob"], "dst": ["tag:web:443"] }
+        ]
+      }`;
+
+      const ranges = locateRules(policy);
+      const { rules } = evaluatePolicy(policy, NODES);
+
+      expect(ranges.map((r) => r.index)).toEqual([0, 1, 2]);
+      for (const rule of rules) {
+        const range = ranges.find((r) => r.index === rule.index);
+        expect(policy.slice(range!.start, range!.end)).toContain(rule.src[0]);
+      }
+    });
+
+    test("comments between rules do not shift or split ranges", () => {
+      const policy = `{
+        "acls": [
+          // first rule
+          { "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] },
+          /* second, with a , and a } inside the comment */
+          { "action": "accept", "src": ["bob"], "dst": ["tag:web:443"] }
+        ]
+      }`;
+
+      expect(slices(policy)).toEqual([
+        `{ "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] }`,
+        `{ "action": "accept", "src": ["bob"], "dst": ["tag:web:443"] }`,
+      ]);
+    });
+
+    test("braces and commas inside strings do not end a rule early", () => {
+      const policy = `{
+        "acls": [
+          { "action": "accept", "src": ["a},b"], "dst": ["tag:web:80"] }
+        ]
+      }`;
+
+      expect(slices(policy)).toEqual([
+        `{ "action": "accept", "src": ["a},b"], "dst": ["tag:web:80"] }`,
+      ]);
+    });
+
+    test("a trailing comma does not invent an extra rule", () => {
+      const policy = `{
+        "acls": [
+          { "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] },
+        ]
+      }`;
+
+      expect(locateRules(policy)).toHaveLength(1);
+    });
+
+    test("rules spanning multiple lines are captured whole", () => {
+      const policy = `{
+        "acls": [
+          {
+            "action": "accept",
+            "src": ["alice"],
+            "dst": ["tag:web:80"]
+          }
+        ]
+      }`;
+
+      const [range] = locateRules(policy);
+      const text = policy.slice(range.start, range.end);
+      expect(text.startsWith("{")).toBe(true);
+      expect(text.endsWith("}")).toBe(true);
+      expect(text).toContain("alice");
+    });
+
+    test("an acls key nested inside another value is not mistaken for the real one", () => {
+      const policy = `{
+        "hosts": { "acls": "10.0.0.0/8" },
+        "acls": [
+          { "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] }
+        ]
+      }`;
+
+      expect(slices(policy)).toEqual([
+        `{ "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] }`,
+      ]);
+    });
+
+    test("a token can be narrowed to within its rule", () => {
+      const policy = `{
+        "acls": [
+          { "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] },
+          { "action": "accept", "src": ["nobody"], "dst": ["tag:web:80"] }
+        ]
+      }`;
+
+      const rule = locateRules(policy).find((r) => r.index === 1)!;
+      const token = locateRuleToken(policy, rule, "nobody")!;
+
+      expect(policy.slice(token.start, token.end)).toBe("nobody");
+      // Inside the offending rule, not the identical text elsewhere.
+      expect(token.start).toBeGreaterThan(rule.start);
+      expect(token.end).toBeLessThan(rule.end);
+    });
+
+    test("the quoted form wins, so a short token cannot match inside a longer one", () => {
+      const policy = `{
+        "acls": [
+          { "action": "accept", "src": ["bobcat", "bob"], "dst": ["tag:web:80"] }
+        ]
+      }`;
+
+      const rule = locateRules(policy)[0];
+      const token = locateRuleToken(policy, rule, "bob")!;
+      // "bobcat" appears first; only the quoted match is the real "bob".
+      expect(policy.slice(token.start - 1, token.end + 1)).toBe(`"bob"`);
+    });
+
+    test("a dst alias falls back to a bare match, since ports follow it", () => {
+      const policy = `{
+        "acls": [
+          { "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] }
+        ]
+      }`;
+
+      const rule = locateRules(policy)[0];
+      const token = locateRuleToken(policy, rule, "tag:web")!;
+      expect(policy.slice(token.start, token.end)).toBe("tag:web");
+    });
+
+    test("a token that is not in the rule reports nothing to highlight", () => {
+      const policy = `{ "acls": [ { "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] } ] }`;
+      expect(locateRuleToken(policy, locateRules(policy)[0], "absent")).toBeNull();
+    });
+
+    test("a policy with no acls yields no ranges", () => {
+      expect(locateRules(`{ "groups": { "group:eng": ["alice"] } }`)).toEqual([]);
+      expect(locateRules("not json at all")).toEqual([]);
+    });
+  });
+
+  describe("port display", () => {
+    test("adjacent single ports fuse into a range", () => {
+      expect(
+        mergePortRanges([
+          { start: 2456, end: 2456 },
+          { start: 2457, end: 2457 },
+          { start: 2458, end: 2458 },
+        ]),
+      ).toEqual([{ start: 2456, end: 2458 }]);
+    });
+
+    test("overlapping ranges fuse, gaps are preserved", () => {
+      expect(
+        mergePortRanges([
+          { start: 80, end: 90 },
+          { start: 85, end: 100 },
+        ]),
+      ).toEqual([{ start: 80, end: 100 }]);
+
+      expect(
+        mergePortRanges([
+          { start: 22, end: 22 },
+          { start: 80, end: 80 },
+        ]),
+      ).toEqual([
+        { start: 22, end: 22 },
+        { start: 80, end: 80 },
+      ]);
+    });
+
+    test("unsorted input is normalised before merging", () => {
+      expect(
+        mergePortRanges([
+          { start: 2458, end: 2458 },
+          { start: 2456, end: 2456 },
+          { start: 2457, end: 2457 },
+        ]),
+      ).toEqual([{ start: 2456, end: 2458 }]);
+    });
+
+    test("the full range renders as a wildcard, not 0-65535", () => {
+      expect(portTokens([{ start: 0, end: 65535 }])).toEqual(["*"]);
+      expect(summarisePorts([{ start: 0, end: 65535 }])).toBe("all ports");
+    });
+
+    test("formatting collapses runs", () => {
+      const ports = parsePorts("111,2049,2456,2457,2458");
+      expect(formatPorts(ports)).toBe("111, 2049, 2456-2458");
+    });
+
+    test("counting spans ranges rather than tokens", () => {
+      expect(countPorts(parsePorts("111,2049,2456,2457,2458"))).toBe(5);
+      expect(countPorts(parsePorts("8000-8100"))).toBe(101);
+    });
+
+    test("the header summary shows values when few and a count when many", () => {
+      expect(summarisePorts(parsePorts("22"))).toBe("22");
+      expect(summarisePorts(parsePorts("22,80,443"))).toBe("22, 80, 443");
+      // The screenshot case: too many to read at a glance, so count instead.
+      expect(summarisePorts(parsePorts("2049,111,20048,32803,8096,5055"))).toBe("6 ports");
+    });
+  });
+
+  describe("reachability", () => {
+    test("wildcard fan-out reaches every peer and drops self-loops", () => {
+      const { edges } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["*"], "dst": ["*:22"] }`),
+        NODES,
+      );
+
+      // 5 nodes -> every ordered pair except self = 5 * 4.
+      expect(edges).toHaveLength(20);
+      expect(edges.some((e) => e.src === e.dst)).toBe(false);
+    });
+
+    test("rules allowing the same pair merge onto one edge", () => {
+      const { edges } = evaluatePolicy(
+        policyOf(
+          `{ "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] }`,
+          `{ "action": "accept", "src": ["alice"], "dst": ["tag:web:443"] }`,
+        ),
+        NODES,
+      );
+
+      const edge = edges.find((e) => e.src === "1" && e.dst === "4");
+      expect(edge?.rules.map((r) => r.ruleIndex)).toEqual([0, 1]);
+      expect(edge?.rules[1].ports).toEqual([{ start: 443, end: 443 }]);
+    });
+
+    test("edges are directional — a bidirectional pair is two edges", () => {
+      const found = pairs(
+        policyOf(
+          `{ "action": "accept", "src": ["alice"], "dst": ["bob:3000"] }`,
+          `{ "action": "accept", "src": ["bob"], "dst": ["alice:3000"] }`,
+        ),
+      );
+
+      expect(found.has("1>3")).toBe(true);
+      expect(found.has("3>1")).toBe(true);
+    });
+
+    test("each edge rule records the dst token that matched it", () => {
+      // A rule can name many destinations; the panel must show only the one
+      // that produced this edge, not the rule's whole dst list.
+      const { edges } = evaluatePolicy(
+        policyOf(
+          `{ "action": "accept", "src": ["alice"], "dst": ["tag:web:80", "bob:22", "100.64.0.5:*"] }`,
+        ),
+        NODES,
+      );
+
+      const toWeb = edges.find((e) => e.src === "1" && e.dst === "4");
+      const toBob = edges.find((e) => e.src === "1" && e.dst === "3");
+      expect(toWeb?.rules[0].dstAlias).toBe("tag:web");
+      expect(toBob?.rules[0].dstAlias).toBe("bob");
+    });
+
+    test("proto and ports ride along on the edge for click-through", () => {
+      const { edges } = evaluatePolicy(
+        policyOf(
+          `{ "action": "accept", "proto": "tcp", "src": ["alice"], "dst": ["tag:web:22,8000-8100"] }`,
+        ),
+        NODES,
+      );
+
+      expect(edges[0].rules[0].proto).toBe("tcp");
+      expect(edges[0].rules[0].ports).toEqual([
+        { start: 22, end: 22 },
+        { start: 8000, end: 8100 },
+      ]);
+    });
+
+    test("parsed rules are exposed, indexed by source position not array slot", () => {
+      // acls[1] is skipped as non-accept, so the surviving rule keeps index 2
+      // even though it is the second entry in the array.
+      const { rules } = evaluatePolicy(
+        policyOf(
+          `{ "action": "accept", "src": ["alice"], "dst": ["tag:web:80"] }`,
+          `{ "action": "deny", "src": ["bob"], "dst": ["tag:web:80"] }`,
+          `{ "action": "accept", "src": ["bob"], "dst": ["tag:web:443"] }`,
+        ),
+        NODES,
+      );
+
+      expect(rules.map((r) => r.index)).toEqual([0, 2]);
+      expect(rules[1].src).toEqual(["bob"]);
+      expect(rules[1].dst[0].raw).toBe("tag:web:443");
+    });
+
+    test("reachOut and reachIn are inverses of the edge list", () => {
+      const { reachOut, reachIn } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["tag:web:*"] }`),
+        NODES,
+      );
+
+      expect(reachOut.get("1")).toEqual(["4"]);
+      expect(reachOut.get("2")).toEqual(["4"]);
+      expect(reachIn.get("4")?.sort()).toEqual(["1", "2"]);
+      expect(reachIn.has("1")).toBe(false);
+    });
+  });
+
+  describe("alias expansion", () => {
+    test("a bare user token matches all of that user's nodes", () => {
+      expect(pairs(policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["bob:*"] }`))).toEqual(
+        new Set(["1>3", "2>3"]),
+      );
+    });
+
+    test("a trailing @ on a user token is normalized away", () => {
+      expect(
+        pairs(policyOf(`{ "action": "accept", "src": ["alice@"], "dst": ["bob@:*"] }`)),
+      ).toEqual(new Set(["1>3", "2>3"]));
+    });
+
+    test("groups expand recursively through nested groups", () => {
+      const found = pairs(`{
+        "groups": {
+          "group:eng": ["alice", "group:ops"],
+          "group:ops": ["bob"]
+        },
+        "acls": [ { "action": "accept", "src": ["group:eng"], "dst": ["tag:web:*"] } ]
+      }`);
+
+      expect(found).toEqual(new Set(["1>4", "2>4", "3>4"]));
+    });
+
+    test("a group cycle terminates instead of hanging", () => {
+      const found = pairs(`{
+        "groups": { "group:a": ["group:b"], "group:b": ["group:a", "alice"] },
+        "acls": [ { "action": "accept", "src": ["group:a"], "dst": ["tag:web:*"] } ]
+      }`);
+
+      expect(found).toEqual(new Set(["1>4", "2>4"]));
+    });
+
+    test("autogroup:member is untagged user devices; autogroup:tagged is the rest", () => {
+      expect(
+        pairs(
+          policyOf(`{ "action": "accept", "src": ["autogroup:member"], "dst": ["tag:web:*"] }`),
+        ),
+      ).toEqual(new Set(["1>4", "2>4", "3>4"]));
+
+      expect(
+        pairs(policyOf(`{ "action": "accept", "src": ["autogroup:tagged"], "dst": ["bob:*"] }`)),
+      ).toEqual(new Set(["4>3", "5>3"]));
+    });
+
+    test("host aliases resolve through their CIDR", () => {
+      const found = pairs(`{
+        "hosts": { "server": "100.64.0.3/32" },
+        "acls": [ { "action": "accept", "src": ["alice"], "dst": ["server:80"] } ]
+      }`);
+
+      expect(found).toEqual(new Set(["1>3", "2>3"]));
+    });
+
+    test("a bare IP behaves as a /32, and a CIDR matches every node inside it", () => {
+      expect(
+        pairs(policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["100.64.0.3:80"] }`)),
+      ).toEqual(new Set(["1>3", "2>3"]));
+
+      expect(
+        pairs(
+          policyOf(`{ "action": "accept", "src": ["100.64.0.1/32"], "dst": ["100.64.0.0/24:*"] }`),
+        ),
+      ).toEqual(new Set(["1>2", "1>3", "1>4", "1>5"]));
+    });
+  });
+
+  describe("autogroup:self couples src and dst", () => {
+    // The load-bearing decision: dst is expanded per-src, so autogroup:self
+    // resolves against each source node's owner. A single static matrix would
+    // get this wrong.
+    test("resolves to the source node's own untagged devices", () => {
+      const found = pairs(
+        policyOf(`{ "action": "accept", "src": ["*"], "dst": ["autogroup:self:*"] }`),
+      );
+
+      // alice's two devices see each other; bob has only one, so he gets none.
+      expect(found).toEqual(new Set(["1>2", "2>1"]));
+    });
+
+    test("a tag-only source has no owner, so it warns instead of matching", () => {
+      const { edges, warnings } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["tag:web"], "dst": ["autogroup:self:*"] }`),
+        NODES,
+      );
+
+      expect(edges).toEqual([]);
+      expect(warnings.some((w) => /autogroup:self needs a dst context/.test(w.message))).toBe(true);
+    });
+
+    test("it is omitted from static expansions, which have no answer for it", () => {
+      const { expansions } = evaluatePolicy(
+        policyOf(
+          `{ "action": "accept", "src": ["alice"], "dst": ["autogroup:self:*", "tag:web:*"] }`,
+        ),
+        NODES,
+      );
+
+      expect(expansions.has("autogroup:self")).toBe(false);
+      expect(expansions.get("tag:web")).toEqual(["4"]);
+      expect(expansions.get("alice")).toEqual(["1", "2"]);
+    });
+  });
+
+  describe("the internet sentinel", () => {
+    test("autogroup:internet becomes one edge per source to a single hub", () => {
+      const { edges } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["autogroup:internet:*"] }`),
+        NODES,
+      );
+
+      expect(edges.map((e) => `${e.src}>${e.dst}`).sort()).toEqual([
+        `1>${INTERNET}`,
+        `2>${INTERNET}`,
+      ]);
+      // The hub is a sentinel, never a real node id.
+      expect(NODES.some((n) => n.id === INTERNET)).toBe(false);
+    });
+
+    test("it is rejected as a src", () => {
+      const { edges, warnings } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["autogroup:internet"], "dst": ["tag:web:*"] }`),
+        NODES,
+      );
+
+      expect(edges).toEqual([]);
+      expect(warnings.some((w) => /not valid as a src/.test(w.message))).toBe(true);
+    });
+  });
+
+  describe("warnings", () => {
+    test("an alias matching nothing is reported", () => {
+      const { warnings } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["nobody"], "dst": ["tag:web:*"] }`),
+        NODES,
+      );
+
+      expect(warnings.some((w) => /Unresolved alias "nobody"/.test(w.message))).toBe(true);
+    });
+
+    test("an undefined group is reported", () => {
+      const { warnings } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["group:ghost"], "dst": ["tag:web:*"] }`),
+        NODES,
+      );
+
+      expect(warnings.some((w) => /Undefined group "group:ghost"/.test(w.message))).toBe(true);
+    });
+
+    test("warnings carry the rule that caused them, so the UI can jump there", () => {
+      const { warnings } = evaluatePolicy(
+        policyOf(
+          `{ "action": "accept", "src": ["alice"], "dst": ["tag:web:*"] }`,
+          `{ "action": "accept", "src": ["nobody"], "dst": ["tag:web:*"] }`,
+        ),
+        NODES,
+      );
+
+      const unresolved = warnings.find((w) => /Unresolved alias/.test(w.message));
+      expect(unresolved?.ruleIndex).toBe(1);
+    });
+
+    test("an unknown autogroup is reported", () => {
+      const { warnings } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["autogroup:nonsense"], "dst": ["tag:web:*"] }`),
+        NODES,
+      );
+
+      expect(warnings.some((w) => /Unknown autogroup/.test(w.message))).toBe(true);
+    });
+  });
+
+  describe("resilience against unfamiliar policies", () => {
+    // This feature was built against a single real policy, so the evaluator
+    // has to survive shapes nobody here has seen.
+    test.each([
+      ["no acls key at all", "{}"],
+      ["acls is not an array", `{ "acls": {} }`],
+      ["a rule missing src and dst", `{ "acls": [ { "action": "accept" } ] }`],
+      [
+        "src and dst of the wrong type",
+        `{ "acls": [ { "action": "accept", "src": 1, "dst": 2 } ] }`,
+      ],
+      ["a null entry in the rule list", `{ "acls": [ null ] }`],
+      [
+        "nonsense port specs",
+        `{ "acls": [ { "action": "accept", "src": ["*"], "dst": ["*:abc"] } ] }`,
+      ],
+      ["a negative port", `{ "acls": [ { "action": "accept", "src": ["*"], "dst": ["*:-5"] } ] }`],
+      ["an empty policy", ""],
+      ["only a comment", "// nothing here"],
+      [
+        "deeply nested junk",
+        `{ "acls": [ { "action": "accept", "src": [[[["*"]]]], "dst": [{}] } ] }`,
+      ],
+    ])("does not throw on %s", (_label, policy) => {
+      expect(() => evaluatePolicy(policy, NODES)).not.toThrow();
+    });
+
+    test("a group that includes itself terminates", () => {
+      expect(() =>
+        evaluatePolicy(
+          `{
+            "groups": { "group:loop": ["group:loop"] },
+            "acls": [ { "action": "accept", "src": ["group:loop"], "dst": ["tag:web:*"] } ]
+          }`,
+          NODES,
+        ),
+      ).not.toThrow();
+    });
+
+    test("a wildcard blow-up is capped rather than left to hang the browser", () => {
+      // 200 nodes with *:* is 39,800 edges; the cap keeps it well under that.
+      const many = Array.from({ length: 200 }, (_, i) =>
+        node({ id: `n${i}`, user: `user${i}`, ips: [`10.1.${Math.floor(i / 256)}.${i % 256}`] }),
+      );
+
+      const { edges, warnings } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["*"], "dst": ["*:*"] }`),
+        many,
+      );
+
+      expect(edges.length).toBeLessThanOrEqual(20_000);
+      expect(warnings.some((w) => /more than .* flows/.test(w.message))).toBe(true);
+    });
+  });
+
+  describe("off-mesh subnets", () => {
+    test("a dst CIDR matching no node becomes a subnet pseudo-node", () => {
+      const { edges, subnets, warnings } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["192.168.1.0/24:*"] }`),
+        NODES,
+      );
+
+      const id = subnetNodeId("192.168.1.0/24");
+      expect(edges.map((e) => `${e.src}>${e.dst}`).sort()).toEqual([`1>${id}`, `2>${id}`]);
+      expect(subnets).toEqual([{ id, cidr: "192.168.1.0/24", routers: ["5"] }]);
+      expect(warnings).toEqual([]);
+    });
+
+    test("each distinct CIDR gets its own node rather than one shared hub", () => {
+      const { subnets } = evaluatePolicy(
+        policyOf(
+          `{ "action": "accept", "src": ["alice"], "dst": ["192.168.1.0/24:*", "10.0.0.0/8:*"] }`,
+        ),
+        NODES,
+      );
+
+      expect(subnets.map((s) => s.cidr).sort()).toEqual(["10.0.0.0/8", "192.168.1.0/24"]);
+    });
+
+    test("the same CIDR reached from two rules collapses to one node", () => {
+      const { subnets } = evaluatePolicy(
+        policyOf(
+          `{ "action": "accept", "src": ["alice"], "dst": ["192.168.1.0/24:80"] }`,
+          `{ "action": "accept", "src": ["bob"], "dst": ["192.168.1.0/24:443"] }`,
+        ),
+        NODES,
+      );
+
+      expect(subnets).toHaveLength(1);
+    });
+
+    test("routers are found by route containment, not just exact match", () => {
+      // ROUTER advertises 192.168.1.0/24, which covers this narrower dst.
+      const { subnets } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["192.168.1.128/25:*"] }`),
+        NODES,
+      );
+
+      expect(subnets[0].routers).toEqual(["5"]);
+    });
+
+    test("a route narrower than the dst does not count as routing it", () => {
+      // This router advertises 192.168.0.0/24, which sits INSIDE the /16 dst
+      // and shares its prefix — so only the mask comparison rejects it.
+      const narrowRouter = node({
+        id: "9",
+        tags: ["tag:r2"],
+        ips: ["100.64.0.9"],
+        routes: ["192.168.0.0/24"],
+      });
+
+      const { subnets } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["192.168.0.0/16:*"] }`),
+        [...NODES, narrowRouter],
+      );
+
+      expect(subnets[0].routers).toEqual([]);
+    });
+
+    test("an unrouted subnet is still drawn, but with no routers", () => {
+      const { subnets } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["172.16.0.0/12:*"] }`),
+        NODES,
+      );
+
+      expect(subnets[0].routers).toEqual([]);
+    });
+
+    test("a host alias pointing off-mesh becomes a subnet too", () => {
+      const { edges, subnets } = evaluatePolicy(
+        `{
+          "hosts": { "lan": "192.168.1.0/24" },
+          "acls": [ { "action": "accept", "src": ["alice"], "dst": ["lan:443"] } ]
+        }`,
+        NODES,
+      );
+
+      expect(subnets[0].cidr).toBe("192.168.1.0/24");
+      expect(edges).toHaveLength(2);
+    });
+
+    test("a CIDR that does match real nodes stays a normal edge", () => {
+      const { edges, subnets } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["alice"], "dst": ["100.64.0.0/24:*"] }`),
+        NODES,
+      );
+
+      expect(subnets).toEqual([]);
+      expect(edges.every((e) => !isSubnetNodeId(e.dst))).toBe(true);
+    });
+
+    test("an off-mesh range as src is reported, not silently dropped", () => {
+      const { edges, subnets, warnings } = evaluatePolicy(
+        policyOf(`{ "action": "accept", "src": ["192.168.1.0/24"], "dst": ["tag:web:*"] }`),
+        NODES,
+      );
+
+      expect(edges).toEqual([]);
+      expect(subnets).toEqual([]); // src side never mints a pseudo-node
+      expect(warnings.some((w) => /as src cannot be drawn/.test(w.message))).toBe(true);
+    });
+
+    test("subnet ids round-trip back to their CIDR", () => {
+      expect(subnetCidrOf(subnetNodeId("192.168.1.0/24"))).toBe("192.168.1.0/24");
+      expect(subnetCidrOf("3")).toBeNull();
+      expect(isSubnetNodeId(INTERNET)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Relates to #603.

A read-only visual view of what the ACL policy actually permits: a map of machines with a line per permitted flow. A map is created consisting of nodes and lines are drawn between them in a "constellation" where lines or nodes can be filtered accordingly.

**New — `app/utils/acl/` (~930 lines, no server or React imports, so it runs in a loader or the browser)**

- `parse.ts` / `hujson.ts` — HuJSON → typed policy
- `resolve.ts` — alias expansion: `tag:`,` group:` (recursive, cycle-guarded), `autogroup:member/tagged/internet/self`, hosts, IPv4 CIDRs
- `evaluate.ts` — `evaluatePolicy(policy, nodes)` → nodes, edges, per-edge rules, warnings
- `locate.ts` — source offsets, for the jump-to-rule links

**New — `map.client.tsx`**

**Changed (4 files)**

- `acl-loader.ts` — fetches machines for the map, gated on `read_machines`, in a try/catch so a failure degrades the map rather than the editor
- `overview.tsx` — the new tab; tabs become URL-controlled so jump-to-rule is a real history entry; Save/Discard hidden on the map tab only
- `cm.client.tsx` — optional highlight prop so the editor can reveal a rule (selection and scroll only, never a document change)
- `package.json` — adds `@xyflow/react`

Notes

- Strictly read-only: the component has three props and no callbacks, contains no fetch/submit primitive, and its only outward channel is `useSearchParams` (GET). Nothing here can reach the ACL write path.
- Shows the saved policy, with a banner and disabled jump links while the editor has unsaved changes.

**Testing** — 44 new unit tests (261 total, all passing). `pnpm typecheck`, `lint` and `build` clean.

**What the map does**

- **Evaluates the policy.** Resolves every `acls[]` rule against the live machine list — tags, groups (recursive), `autogroup:member/tagged/internet/self`, host aliases, IPv4 CIDRs — into a graph of permitted flows. Internet and off-mesh subnets appear as pseudo-nodes, subnets carrying the routers that serve them.
- **Overview.** All machines on a ring, one line per permitted direction. Hovering a machine highlights its flows in the legend's colours.
- **Filtering by clicking.** Click a machine to add or remove it. One selected shows its whole world; two or more narrows to the traffic **between** them. Toolbar buttons suspend, clear, or hide everything else; a searchable picker (name, tag, owner or IP) does the same by hand.
- **Inspect.** Focuses one machine into lanes — reached-by on the left, can-reach on the right — with an inbound/outbound/all direction filter.
- **Rules panel.** Click any flow for the rules permitting it: rule index, protocol, ports and the endpoints as the policy writes them. With machines selected it lists their flows grouped per conversation.
- **Jump to source.** A magnifier on any rule or warning opens the Edit tab and selects that exact rule — or the offending token — in the policy file.
- **Warnings.** Unresolved aliases, off-mesh sources and wildcard blow-ups are reported inline, each locatable in the file.


I have tested this against my own headscale instance - which means that more testing would be highly appreciated/required with other constellations of ACLs. I'm not sure if the "_Preview rules_" placeholder was supposed to be something like this. here are some screenshots:

Main overview:
<img width="1365" height="1286" alt="map1" src="https://github.com/user-attachments/assets/78d04a03-9d92-4c6a-8e9e-3a0755f65f15" />

Pressing one machine shows the relationship it has to other machines, visually represented by both direction and color according to legend:
<img width="1375" height="1288" alt="map2" src="https://github.com/user-attachments/assets/2c81e20b-7c2a-45f4-94f5-edb7f0b131ca" />

Multiple machines can be pressed (filtered) to see whether they have any active ACL rules to each other:
<img width="1379" height="1288" alt="map3" src="https://github.com/user-attachments/assets/36e35cfa-e430-4e15-8840-6fcf8d50720d" />

_Inbound_ filter used when pressing one machine to see which machines can reach it:
<img width="1374" height="1297" alt="map4" src="https://github.com/user-attachments/assets/c313ba42-f1c6-4983-aec5-c7f3f4c2ba0d" />

Machine inspect mode - for a more focused view on one machine:
<img width="1383" height="1297" alt="map5" src="https://github.com/user-attachments/assets/9ceceafd-4a05-4b54-b735-e76a1af73d57" />

Checking outbound flows in the inspect mode:
<img width="1367" height="1291" alt="map6" src="https://github.com/user-attachments/assets/55da4eee-0f2c-47b9-95b8-fabde54d1c83" />

Multiple nodes selected/added to filter with the "_Hide machines outside of the filter_" toggle active:
<img width="1364" height="1292" alt="map7" src="https://github.com/user-attachments/assets/3c8d4df9-b959-4bbe-a71a-99fa81480965" />

When the magnifying glass on a rule on the right-hand side is clicked, it directs to the related rule in the ACL editor:
<img width="1362" height="1291" alt="map8" src="https://github.com/user-attachments/assets/c36f6ce4-f318-4aa0-b61a-001d2eb56b03" />

Representation of the filter dropdown menu:
<img width="1368" height="1290" alt="map9" src="https://github.com/user-attachments/assets/2cdd66af-b2ab-467b-bb64-dc162456a5e0" />
