### PR TITLE
feat(acls): add HuJSON formatting and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+## Changes
+
+- The Access Control file editor now formats HuJSON, preserves comments while formatting, and shows syntax errors before an invalid policy can be saved.
+
 # 0.7.1 (August 27, 2026)
 
 ## Changes

--- a/app/routes/acls/acl-action.ts
+++ b/app/routes/acls/acl-action.ts
@@ -3,6 +3,7 @@ import { data } from "react-router";
 import { authContext, requestApiContext } from "~/server/context";
 import { isDataWithApiError } from "~/server/headscale/api/error-client";
 import { Capabilities } from "~/server/web/roles";
+import { validatePolicy } from "~/utils/acl-policy";
 
 import type { Route } from "./+types/overview";
 
@@ -24,10 +25,23 @@ export async function aclAction({ request, context }: Route.ActionArgs) {
   // Try to write to the ACL policy via the API or via config file (TODO).
   const formData = await request.formData();
   const policyData = formData.get("policy")?.toString();
-  if (!policyData) {
+  if (!policyData || policyData.trim().length === 0) {
     throw data("Missing `policy` in the form data.", {
       status: 400,
     });
+  }
+
+  const syntaxErrors = validatePolicy(policyData);
+  if (syntaxErrors.length > 0) {
+    return data(
+      {
+        success: false,
+        error: `Syntax error: ${syntaxErrors[0].message}`,
+        policy: undefined,
+        updatedAt: undefined,
+      },
+      400,
+    );
   }
 
   const { api } = await getRequestApi(request);

--- a/app/routes/acls/components/cm.client.tsx
+++ b/app/routes/acls/components/cm.client.tsx
@@ -1,8 +1,12 @@
+import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
 import * as shopify from "@shopify/lang-jsonc";
 import CodeMirror from "@uiw/react-codemirror";
-import { BookCopy, CircleX } from "lucide-react";
+import { BookCopy, Braces, CircleCheck, CircleX } from "lucide-react";
 import Merge from "react-codemirror-merge";
 import { ErrorBoundary } from "react-error-boundary";
+
+import Button from "~/components/button";
+import { formatPolicy, validatePolicy } from "~/utils/acl-policy";
 
 import { headplaneTheme } from "./theme";
 
@@ -13,6 +17,9 @@ interface EditorProps {
 }
 
 export function Editor(props: EditorProps) {
+  const diagnostics = validatePolicy(props.value);
+  const firstError = diagnostics[0];
+
   return (
     <div className="text-sm">
       <ErrorBoundary
@@ -23,9 +30,39 @@ export function Editor(props: EditorProps) {
           </div>
         }
       >
+        <div className="flex items-center justify-between gap-4 border-b border-[var(--cm-gutter-border)] bg-[var(--cm-bg)] px-3 py-2 text-[var(--cm-fg)]">
+          <div
+            role="status"
+            className={
+              firstError
+                ? "flex min-w-0 items-center gap-2 text-red-600 dark:text-red-400"
+                : "flex items-center gap-2 text-green-700 dark:text-green-400"
+            }
+          >
+            {firstError ? (
+              <CircleX className="size-4 shrink-0" />
+            ) : (
+              <CircleCheck className="size-4 shrink-0" />
+            )}
+            <span className="truncate">
+              {firstError ? firstError.message : "Valid HuJSON syntax"}
+            </span>
+          </div>
+          <Button
+            disabled={props.isDisabled || firstError !== undefined}
+            onClick={() => {
+              const result = formatPolicy(props.value);
+              if (result.ok) props.onChange(result.value);
+            }}
+            type="button"
+          >
+            <Braces className="size-4" />
+            Format
+          </Button>
+        </div>
         <CodeMirror
           editable={!props.isDisabled}
-          extensions={[shopify.jsonc()]}
+          extensions={[shopify.jsonc(), policyLinter, lintGutter()]}
           minHeight="24rem"
           maxHeight="var(--height-editor)"
           onChange={(value) => props.onChange(value)}
@@ -37,6 +74,14 @@ export function Editor(props: EditorProps) {
     </div>
   );
 }
+
+const policyLinter = linter((view): Diagnostic[] =>
+  validatePolicy(view.state.doc.toString()).map((diagnostic) => ({
+    ...diagnostic,
+    severity: "error",
+    source: "HuJSON",
+  })),
+);
 
 interface DifferProps {
   left: string;

--- a/app/routes/acls/components/cm.client.tsx
+++ b/app/routes/acls/components/cm.client.tsx
@@ -1,7 +1,7 @@
 import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
 import * as shopify from "@shopify/lang-jsonc";
 import CodeMirror from "@uiw/react-codemirror";
-import { BookCopy, Braces, CircleCheck, CircleX } from "lucide-react";
+import { BookCopy, Braces, CircleCheck, CircleDashed, CircleX } from "lucide-react";
 import Merge from "react-codemirror-merge";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -17,6 +17,7 @@ interface EditorProps {
 }
 
 export function Editor(props: EditorProps) {
+  const isEmpty = props.value.trim().length === 0;
   const diagnostics = validatePolicy(props.value);
   const firstError = diagnostics[0];
 
@@ -36,20 +37,24 @@ export function Editor(props: EditorProps) {
             className={
               firstError
                 ? "flex min-w-0 items-center gap-2 text-red-600 dark:text-red-400"
-                : "flex items-center gap-2 text-green-700 dark:text-green-400"
+                : isEmpty
+                  ? "flex items-center gap-2 opacity-70"
+                  : "flex items-center gap-2 text-green-700 dark:text-green-400"
             }
           >
             {firstError ? (
               <CircleX className="size-4 shrink-0" />
+            ) : isEmpty ? (
+              <CircleDashed className="size-4 shrink-0" />
             ) : (
               <CircleCheck className="size-4 shrink-0" />
             )}
             <span className="truncate">
-              {firstError ? firstError.message : "Valid HuJSON syntax"}
+              {firstError ? firstError.message : isEmpty ? "No policy yet" : "Valid HuJSON syntax"}
             </span>
           </div>
           <Button
-            disabled={props.isDisabled || firstError !== undefined}
+            disabled={props.isDisabled || isEmpty || firstError !== undefined}
             onClick={() => {
               const result = formatPolicy(props.value);
               if (result.ok) props.onChange(result.value);

--- a/app/routes/acls/overview.tsx
+++ b/app/routes/acls/overview.tsx
@@ -225,7 +225,11 @@ export default function Page({
       <Button
         className="mr-2"
         disabled={
-          disabled || fetcher.state !== "idle" || codePolicy.length === 0 || codePolicy === policy
+          disabled ||
+          fetcher.state !== "idle" ||
+          codePolicy.trim().length === 0 ||
+          !parsed.ok ||
+          codePolicy === policy
         }
         onClick={() => {
           const formData = new FormData();

--- a/app/utils/acl-policy.ts
+++ b/app/utils/acl-policy.ts
@@ -1,3 +1,12 @@
+import {
+  applyEdits,
+  format as formatJson,
+  getNodeValue,
+  parseTree,
+  printParseErrorCode,
+  type ParseError,
+} from "jsonc-parser";
+
 import { scanHuJson } from "~/utils/node-info";
 
 // A structured view over the Headscale ACL policy (HuJSON), which Headscale
@@ -41,6 +50,14 @@ export type ParseResult =
   | { ok: true; policy: Policy; hasComments: boolean }
   | { ok: false; error: string };
 
+export type FormatResult = { ok: true; value: string } | { ok: false; error: string };
+
+export interface PolicyDiagnostic {
+  from: number;
+  to: number;
+  message: string;
+}
+
 export const EMPTY_POLICY: Policy = {
   groups: {},
   tagOwners: {},
@@ -58,22 +75,12 @@ export function parsePolicy(raw: string): ParseResult {
     return { ok: true, policy: structuredClone(EMPTY_POLICY), hasComments: false };
   }
 
-  const { stripped, hasComments } = scanHuJson(raw);
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stripped);
-  } catch (error) {
-    return {
-      ok: false,
-      error: error instanceof Error ? error.message : "The policy is not valid HuJSON",
-    };
-  }
+  const result = parseHuJson(raw);
+  if (!result.ok) return result;
 
-  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { ok: false, error: "The policy must be a JSON object" };
-  }
+  const { parsed, hasComments } = result;
 
-  const record = parsed as Record<string, unknown>;
+  const record = parsed;
   const extra: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
     if (!KNOWN_KEYS.includes(key)) {
@@ -94,6 +101,86 @@ export function parsePolicy(raw: string): ParseResult {
       keyOrder: Object.keys(record),
     },
   };
+}
+
+export function formatPolicy(raw: string): FormatResult {
+  if (raw.trim().length === 0) {
+    return { ok: false, error: "The policy is empty" };
+  }
+
+  const result = parseHuJson(raw);
+  if (!result.ok) return result;
+
+  const edits = formatJson(raw, undefined, {
+    eol: "\n",
+    insertFinalNewline: true,
+    insertSpaces: true,
+    keepLines: false,
+    tabSize: 2,
+  });
+  return { ok: true, value: applyEdits(raw, edits) };
+}
+
+type HuJsonResult =
+  | { ok: true; parsed: Record<string, unknown>; hasComments: boolean }
+  | { ok: false; error: string };
+
+function parseHuJson(raw: string): HuJsonResult {
+  const errors: ParseError[] = [];
+  const tree = parseTree(raw, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    const first = errors[0];
+    return {
+      ok: false,
+      error: withLocation(raw, humanizeParseError(first), first.offset),
+    };
+  }
+
+  if (tree?.type !== "object") {
+    return { ok: false, error: "The policy must be a JSON object" };
+  }
+
+  return {
+    ok: true,
+    parsed: getNodeValue(tree) as Record<string, unknown>,
+    hasComments: scanHuJson(raw).hasComments,
+  };
+}
+
+export function validatePolicy(raw: string): PolicyDiagnostic[] {
+  if (raw.trim().length === 0) {
+    return [{ from: 0, to: 0, message: "The policy is empty" }];
+  }
+
+  const errors: ParseError[] = [];
+  const tree = parseTree(raw, errors, { allowTrailingComma: true });
+  const diagnostics = errors.map((error) => ({
+    from: error.offset,
+    to: Math.min(raw.length, error.offset + Math.max(1, error.length)),
+    message: humanizeParseError(error),
+  }));
+
+  if (diagnostics.length === 0 && tree?.type !== "object") {
+    diagnostics.push({
+      from: 0,
+      to: raw.length,
+      message: "The policy must be a JSON object",
+    });
+  }
+
+  return diagnostics;
+}
+
+function humanizeParseError(error: ParseError): string {
+  return printParseErrorCode(error.error).replace(/([a-z])([A-Z])/g, "$1 $2");
+}
+
+function withLocation(raw: string, message: string, offset: number): string {
+  const before = raw.slice(0, offset);
+  const line = before.split(/\r\n|\r|\n/).length;
+  const lastLineBreak = Math.max(before.lastIndexOf("\n"), before.lastIndexOf("\r"));
+  const column = offset - lastLineBreak;
+  return `${message} at line ${line}, column ${column}`;
 }
 
 export function serializePolicy(policy: Policy): string {

--- a/app/utils/acl-policy.ts
+++ b/app/utils/acl-policy.ts
@@ -111,11 +111,13 @@ export function formatPolicy(raw: string): FormatResult {
   const result = parseHuJson(raw);
   if (!result.ok) return result;
 
+  // Line breaks are kept: a hand-written policy groups rules with blank lines
+  // and keeps short arrays inline, and reflowing would throw both away.
   const edits = formatJson(raw, undefined, {
     eol: "\n",
     insertFinalNewline: true,
     insertSpaces: true,
-    keepLines: false,
+    keepLines: true,
     tabSize: 2,
   });
   return { ok: true, value: applyEdits(raw, edits) };
@@ -147,9 +149,11 @@ function parseHuJson(raw: string): HuJsonResult {
   };
 }
 
+// An empty policy is not a syntax error; like `parsePolicy`, it is treated as
+// the "no policy yet" state and the caller decides what that means.
 export function validatePolicy(raw: string): PolicyDiagnostic[] {
   if (raw.trim().length === 0) {
-    return [{ from: 0, to: 0, message: "The policy is empty" }];
+    return [];
   }
 
   const errors: ParseError[] = [];

--- a/docs/features/acls.md
+++ b/docs/features/acls.md
@@ -69,7 +69,12 @@ The **Edit file** tab is the original CodeMirror editor over the raw policy, and
 editors write into the same buffer, so a change made visually shows up in the
 file editor and in the diff before it is saved.
 
-Nothing is sent to Headscale until **Save** is pressed.
+The file editor validates HuJSON as you type and marks syntax errors inline.
+Invalid policies cannot be saved. **Format** applies consistent two-space
+indentation while preserving HuJSON comments and trailing commas.
+
+Nothing is sent to Headscale until **Save** is pressed. Headplane also repeats
+the syntax validation on the server before sending the policy to Headscale.
 
 ::: warning Comments are not preserved
 HuJSON allows comments and trailing commas. Headplane reads them, but the

--- a/docs/features/acls.md
+++ b/docs/features/acls.md
@@ -71,7 +71,8 @@ file editor and in the diff before it is saved.
 
 The file editor validates HuJSON as you type and marks syntax errors inline.
 Invalid policies cannot be saved. **Format** applies consistent two-space
-indentation while preserving HuJSON comments and trailing commas.
+indentation and spacing while keeping the existing line breaks, HuJSON comments
+and trailing commas.
 
 Nothing is sent to Headscale until **Save** is pressed. Headplane also repeats
 the syntax validation on the server before sending the policy to Headscale.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -33,7 +33,7 @@ in
     inherit (finalAttrs) pname version src;
 		fetcherVersion = 3;
 		pnpm = pnpm_10;
-		hash = "sha256-+J36edYqr+qt6C0fU8Q8visrEH5+R6Ww3VuRcykHgZY=";
+		hash = "sha256-bsCSXUnTtB2t2WvKK87dC80Ww0pHcNhVweh9XdSHR+8=";
   };
 
     buildPhase = ''

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@base-ui/react": "^1.7.0",
     "@codemirror/language": "^6.12.4",
+    "@codemirror/lint": "^6.9.7",
     "@codemirror/view": "^6.43.9",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^7.0.0",
@@ -41,6 +42,7 @@
     "isbot": "5.2.1",
     "jose": "6.2.10",
     "js-yaml": "^5.4.0",
+    "jsonc-parser": "^3.3.1",
     "lucide-react": "^1.34.0",
     "mime": "^4.1.0",
     "pino": "^10.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@codemirror/language':
         specifier: ^6.12.4
         version: 6.12.4
+      '@codemirror/lint':
+        specifier: ^6.9.7
+        version: 6.9.7
       '@codemirror/view':
         specifier: ^6.43.9
         version: 6.43.9
@@ -56,7 +59,7 @@ importers:
         version: 8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
       '@uiw/react-codemirror':
         specifier: 4.25.11
-        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       arktype:
         specifier: ^2.2.3
         version: 2.2.3
@@ -75,6 +78,9 @@ importers:
       js-yaml:
         specifier: ^5.4.0
         version: 5.4.0
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       lucide-react:
         specifier: ^1.34.0
         version: 1.34.0(react@19.2.8)
@@ -89,7 +95,7 @@ importers:
         version: 19.2.8
       react-codemirror-merge:
         specifier: 4.25.11
-        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
@@ -437,6 +443,9 @@ packages:
 
   '@codemirror/lint@6.8.2':
     resolution: {integrity: sha512-PDFG5DjHxSEjOXk9TQYYVjZDqlZTFaDBfhQixHnQOEVDDNHUbEh/hstAjcQJaA6FQdZTD1hquXTK0rVBLADR1g==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
 
   '@codemirror/merge@6.12.2':
     resolution: {integrity: sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==}
@@ -2717,6 +2726,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonpath-plus@10.4.0:
     resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
     engines: {node: '>=18.0.0'}
@@ -4264,6 +4276,12 @@ snapshots:
       '@codemirror/view': 6.43.9
       crelt: 1.0.7
 
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.9
+      crelt: 1.0.7
+
   '@codemirror/merge@6.12.2':
     dependencies:
       '@codemirror/language': 6.12.4
@@ -5251,24 +5269,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)':
+  '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)':
     dependencies:
       '@codemirror/autocomplete': 6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2)
       '@codemirror/commands': 6.11.0
       '@codemirror/language': 6.12.4
-      '@codemirror/lint': 6.8.2
+      '@codemirror/lint': 6.9.7
       '@codemirror/search': 6.5.7
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.9
 
-  '@uiw/react-codemirror@4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@uiw/react-codemirror@4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@codemirror/commands': 6.11.0
       '@codemirror/state': 6.6.0
       '@codemirror/theme-one-dark': 6.1.2
       '@codemirror/view': 6.43.9
-      '@uiw/codemirror-extensions-basic-setup': 4.25.11(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)
+      '@uiw/codemirror-extensions-basic-setup': 4.25.11(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)
       codemirror: 6.0.1(@lezer/common@1.5.2)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -6144,6 +6162,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   jsonpath-plus@10.4.0:
     dependencies:
       '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
@@ -6707,14 +6727,14 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  react-codemirror-merge@4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-codemirror-merge@4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.29.7
       '@codemirror/merge': 6.12.2
       '@codemirror/state': 6.6.0
       '@codemirror/theme-one-dark': 6.1.2
       '@codemirror/view': 6.43.9
-      '@uiw/react-codemirror': 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.8.2)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@uiw/react-codemirror': 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.18.2(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.9)(@lezer/common@1.5.2))(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.5.7)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.43.9)(codemirror@6.0.1(@lezer/common@1.5.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       codemirror: 6.0.1(@lezer/common@1.5.2)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)

--- a/tests/unit/acls/acl-action.test.ts
+++ b/tests/unit/acls/acl-action.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { aclAction } from "~/routes/acls/acl-action";
+import { authContext, requestApiContext } from "~/server/context";
+
+function requestWithPolicy(policy: string): Request {
+  const formData = new FormData();
+  formData.set("policy", policy);
+  return { formData: () => Promise.resolve(formData) } as unknown as Request;
+}
+
+describe("ACL action validation", () => {
+  test("rejects invalid HuJSON before calling Headscale", async () => {
+    const getRequestApi = vi.fn();
+    const context = {
+      get: (key: typeof authContext | typeof requestApiContext) => {
+        if (key === authContext) {
+          return {
+            require: vi.fn().mockResolvedValue({}),
+            can: () => true,
+          };
+        }
+        if (key === requestApiContext) return getRequestApi;
+        return undefined;
+      },
+    };
+
+    const result = (await aclAction({
+      request: requestWithPolicy(`{ "groups": [ }`),
+      context,
+      params: {},
+    } as never)) as { data: { success: boolean; error: string }; init?: { status?: number } };
+
+    expect(result.init?.status).toBe(400);
+    expect(result.data).toMatchObject({ success: false, error: expect.stringContaining("Syntax") });
+    expect(getRequestApi).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/acl-policy.test.ts
+++ b/tests/unit/utils/acl-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   asUserReference,
+  formatPolicy,
   groupsForUser,
   hasPortSpec,
   isValidGroupName,
@@ -12,6 +13,7 @@ import {
   policySources,
   serializePolicy,
   setUserGroups,
+  validatePolicy,
   withDefaultPort,
 } from "~/utils/acl-policy";
 
@@ -147,6 +149,32 @@ describe("parsePolicy", () => {
     expect(policy.groups).toEqual({});
     expect(policy.acls).toEqual([]);
     expect(policy.hosts).toEqual({});
+  });
+
+  test("does not treat trailing-comma-like text inside strings as syntax", () => {
+    const { policy } = parseOrThrow(`{ "custom": "keep ,} and ,] intact" }`);
+    expect(policy.extra.custom).toBe("keep ,} and ,] intact");
+  });
+});
+
+describe("formatPolicy", () => {
+  test("formats HuJSON and keeps comments and trailing commas", () => {
+    const result = formatPolicy(`{"groups":{"group:eng":["alice@",],},// team\n"acls":[]}`);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toContain("// team");
+    expect(result.value).toContain('  "groups": {');
+    expect(result.value).toContain('"alice@",');
+    expect(result.value.endsWith("\n")).toBe(true);
+    expect(parsePolicy(result.value).ok).toBe(true);
+
+    const formattedAgain = formatPolicy(result.value);
+    expect(formattedAgain).toEqual(result);
+  });
+
+  test("does not format invalid input", () => {
+    expect(formatPolicy(`{ "groups": [ }`).ok).toBe(false);
   });
 });
 
@@ -321,6 +349,26 @@ describe("destination ports", () => {
 });
 
 describe("validation", () => {
+  test("accepts HuJSON comments and trailing commas", () => {
+    expect(validatePolicy(`{ "groups": {}, // comment\n }`)).toEqual([]);
+  });
+
+  test("reports syntax errors with source ranges", () => {
+    const diagnostics = validatePolicy(`{ "groups": [ }`);
+    expect(diagnostics.length).toBeGreaterThan(0);
+    expect(diagnostics[0]).toMatchObject({
+      from: expect.any(Number),
+      to: expect.any(Number),
+      message: expect.any(String),
+    });
+  });
+
+  test("requires a top-level object", () => {
+    expect(validatePolicy("[]")).toEqual([
+      { from: 0, to: 2, message: "The policy must be a JSON object" },
+    ]);
+  });
+
   test("accepts well-formed names", () => {
     expect(isValidGroupName("group:eng-team")).toBe(true);
     expect(isValidTagName("tag:web-01")).toBe(true);

--- a/tests/unit/utils/acl-policy.test.ts
+++ b/tests/unit/utils/acl-policy.test.ts
@@ -159,18 +159,36 @@ describe("parsePolicy", () => {
 
 describe("formatPolicy", () => {
   test("formats HuJSON and keeps comments and trailing commas", () => {
-    const result = formatPolicy(`{"groups":{"group:eng":["alice@",],},// team\n"acls":[]}`);
+    const result = formatPolicy(
+      `{\n"groups":{\n"group:eng":["alice@",],\n},// team\n"acls":[\n]\n}`,
+    );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
     expect(result.value).toContain("// team");
     expect(result.value).toContain('  "groups": {');
-    expect(result.value).toContain('"alice@",');
+    expect(result.value).toContain('    "group:eng": [ "alice@", ],');
     expect(result.value.endsWith("\n")).toBe(true);
     expect(parsePolicy(result.value).ok).toBe(true);
 
     const formattedAgain = formatPolicy(result.value);
     expect(formattedAgain).toEqual(result);
+  });
+
+  test("keeps blank lines and inline arrays", () => {
+    const result = formatPolicy(
+      `{\n"groups": { "group:eng": ["alice@", "bob@"] },\n\n"acls": [\n// engineers\n{ "action": "accept", "src": ["group:eng"], "dst": ["*:*"] },\n\n{ "action": "accept", "src": ["*"], "dst": ["*:22"] },\n],\n}\n`,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toBe(
+      `{\n  "groups": { "group:eng": [ "alice@", "bob@" ] },\n\n  "acls": [\n    // engineers\n    { "action": "accept", "src": [ "group:eng" ], "dst": [ "*:*" ] },\n\n    { "action": "accept", "src": [ "*" ], "dst": [ "*:22" ] },\n  ],\n}\n`,
+    );
+  });
+
+  test("does not format an empty policy", () => {
+    expect(formatPolicy("  \n").ok).toBe(false);
   });
 
   test("does not format invalid input", () => {
@@ -349,6 +367,11 @@ describe("destination ports", () => {
 });
 
 describe("validation", () => {
+  test("treats an empty policy as having no syntax errors", () => {
+    expect(validatePolicy("")).toEqual([]);
+    expect(validatePolicy("  \n")).toEqual([]);
+  });
+
   test("accepts HuJSON comments and trailing commas", () => {
     expect(validatePolicy(`{ "groups": {}, // comment\n }`)).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- add comment-preserving HuJSON formatting to the raw ACL editor
- show live parse diagnostics and prevent invalid or empty saves
- validate again server-side before sending policies to Headscale
- document the editor behavior and add a Next changelog entry

## Testing

- pnpm run test:unit — 260 passed
- pnpm run typecheck
- pnpm run lint
- pnpm run format
- pnpm run build
- manual ACL editor testing

Follow-up to #607 and #608.